### PR TITLE
Use pipeline output manifests, if present

### DIFF
--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -15,7 +15,11 @@ from airflow.hooks.http_hook import HttpHook
 
 import utils
 
-from utils import localized_assert_json_matches_schema as assert_json_matches_schema
+from utils import (
+    PIPELINE_BASE_DIR,
+    find_pipeline_manifests,
+    localized_assert_json_matches_schema as assert_json_matches_schema,
+)
 
 import cwltool  # used to find its path
 
@@ -94,7 +98,6 @@ with DAG('codex_cytokit',
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
-        pipeline_base_dir = str(Path(__file__).resolve().parent / 'cwl')
         cwltool_dir = os.path.dirname(cwltool.__file__)
         while cwltool_dir:
             part1, part2 = os.path.split(cwltool_dir)
@@ -108,7 +111,7 @@ with DAG('codex_cytokit',
             'env',
             'PATH=%s:%s' % (cwltool_dir, os.environ['PATH']),
             'cwltool',
-            os.path.join(pipeline_base_dir, cwl_workflow1),
+            os.fspath(PIPELINE_BASE_DIR / cwl_workflow1),
             '--data_dir',
             data_dir,
         ]
@@ -174,7 +177,6 @@ with DAG('codex_cytokit',
         print('parent_data_dir: ', parent_data_dir)
         data_dir = os.path.join(tmpdir, 'cwl_out')  # This stage reads input from stage 1
         print('data_dir: ', data_dir)
-        pipeline_base_dir = str(Path(__file__).resolve().parent / 'cwl')
         cwltool_dir = os.path.dirname(cwltool.__file__)
         while cwltool_dir:
             part1, part2 = os.path.split(cwltool_dir)
@@ -188,11 +190,11 @@ with DAG('codex_cytokit',
             'env',
             'PATH=%s:%s' % (cwltool_dir, os.environ['PATH']),
             'cwltool',
-            os.path.join(pipeline_base_dir, cwl_workflow2),
+            os.fspath(PIPELINE_BASE_DIR / cwl_workflow2),
             '--input_dir',
             os.path.join(data_dir, 'output', 'extract', 'expressions', 'ome-tiff')
         ]
-        
+
         command_str = ' '.join(shlex.quote(piece) for piece in command)
         print('final command_str: %s' % command_str)
         return command_str
@@ -318,14 +320,12 @@ with DAG('codex_cytokit',
  
         if success:
             md = {}
-            pipeline_base_dir = os.path.join(os.environ['AIRFLOW_HOME'],
-                                             'dags', 'cwl')
             if 'dag_provenance' in kwargs['dag_run'].conf:
                 md['dag_provenance'] = kwargs['dag_run'].conf['dag_provenance'].copy()
                 new_prv_dct = utils.get_git_provenance_dict([__file__,
-                                                             os.path.join(pipeline_base_dir,
+                                                             os.path.join(PIPELINE_BASE_DIR,
                                                                           cwl_workflow1),
-                                                             os.path.join(pipeline_base_dir,
+                                                             os.path.join(PIPELINE_BASE_DIR,
                                                                           cwl_workflow2)])
                 md['dag_provenance'].update(new_prv_dct)
             else:
@@ -333,13 +333,18 @@ with DAG('codex_cytokit',
                            if 'dag_provenance_list' in kwargs['dag_run'].conf
                            else [])
                 dag_prv.extend(utils.get_git_provenance_list([__file__,
-                                                              os.path.join(pipeline_base_dir,
+                                                              os.path.join(PIPELINE_BASE_DIR,
                                                                            cwl_workflow1),
-                                                              os.path.join(pipeline_base_dir,
+                                                              os.path.join(PIPELINE_BASE_DIR,
                                                                            cwl_workflow2)]))
                 md['dag_provenance_list'] = dag_prv
+            manifest_files = find_pipeline_manifests(
+                PIPELINE_BASE_DIR / cwl_workflow1,
+                PIPELINE_BASE_DIR / cwl_workflow2,
+            )
             md.update(utils.get_file_metadata_dict(ds_dir,
-                                                   utils.get_tmp_dir_path(kwargs['run_id'])))
+                                                   utils.get_tmp_dir_path(kwargs['run_id']),
+                                                   manifest_files))
             try:
                 assert_json_matches_schema(md, 'dataset_metadata_schema.yml')
                 data = {'dataset_id' : derived_dataset_uuid,

--- a/src/ingest-pipeline/airflow/dags/devtest_step2.py
+++ b/src/ingest-pipeline/airflow/dags/devtest_step2.py
@@ -238,7 +238,8 @@ with DAG('devtest_step2',
                 dag_prv.extend(utils.get_git_provenance_list([__file__]))
                 md['dag_provenance_list'] = dag_prv
             md.update(utils.get_file_metadata_dict(ds_dir,
-                                                   utils.get_tmp_dir_path(kwargs['run_id'])))
+                                                   utils.get_tmp_dir_path(kwargs['run_id']),
+                                                   []))
             try:
                 assert_json_matches_schema(md, 'dataset_metadata_schema.yml')
                 data = {'dataset_id' : derived_dataset_uuid,

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
@@ -16,16 +16,14 @@ from airflow.hooks.http_hook import HttpHook
 import utils
 
 from utils import (
+    PIPELINE_BASE_DIR,
     find_pipeline_manifests,
     localized_assert_json_matches_schema as assert_json_matches_schema,
 )
 
-
 import cwltool  # used to find its path
 
 THREADS = 6  # to be used by the CWL worker
-
-PIPELINE_BASE_DIR = Path(__file__).resolve().parent / 'cwl'
 
 
 def get_parent_dataset_uuid(**kwargs):
@@ -320,14 +318,12 @@ with DAG('salmon_rnaseq_10x',
 
         if success:
             md = {}
-            # Is this necessary? Is it the same as the global PIPELINE_BASE_DIR?
-            pipeline_base_dir = Path(os.environ['AIRFLOW_HOME']) / 'dags/cwl'
             if 'dag_provenance' in kwargs['dag_run'].conf:
                 md['dag_provenance'] = kwargs['dag_run'].conf['dag_provenance'].copy()
                 new_prv_dct = utils.get_git_provenance_dict([__file__,
-                                                             os.path.join(pipeline_base_dir,
+                                                             os.path.join(PIPELINE_BASE_DIR,
                                                                           cwl_workflow1),
-                                                             os.path.join(pipeline_base_dir,
+                                                             os.path.join(PIPELINE_BASE_DIR,
                                                                           cwl_workflow2)])
                 md['dag_provenance'].update(new_prv_dct)
             else:
@@ -335,15 +331,15 @@ with DAG('salmon_rnaseq_10x',
                            if 'dag_provenance_list' in kwargs['dag_run'].conf
                            else [])
                 dag_prv.extend(utils.get_git_provenance_list([__file__,
-                                                              os.path.join(pipeline_base_dir,
+                                                              os.path.join(PIPELINE_BASE_DIR,
                                                                            cwl_workflow1),
-                                                              os.path.join(pipeline_base_dir,
+                                                              os.path.join(PIPELINE_BASE_DIR,
                                                                            cwl_workflow2)]))
                 md['dag_provenance_list'] = dag_prv
 
             manifest_files = find_pipeline_manifests(
-                pipeline_base_dir / cwl_workflow1,
-                pipeline_base_dir / cwl_workflow2,
+                PIPELINE_BASE_DIR / cwl_workflow1,
+                PIPELINE_BASE_DIR / cwl_workflow2,
             )
             md.update(utils.get_file_metadata_dict(ds_dir,
                                                    utils.get_tmp_dir_path(kwargs['run_id']),

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
@@ -15,12 +15,18 @@ from airflow.hooks.http_hook import HttpHook
 
 import utils
 
-from utils import localized_assert_json_matches_schema as assert_json_matches_schema
+from utils import (
+    find_pipeline_manifests,
+    localized_assert_json_matches_schema as assert_json_matches_schema,
+)
 
 
 import cwltool  # used to find its path
 
 THREADS = 6  # to be used by the CWL worker
+
+PIPELINE_BASE_DIR = Path(__file__).resolve().parent / 'cwl'
+
 
 def get_parent_dataset_uuid(**kwargs):
     return kwargs['dag_run'].conf['parent_submission_id']
@@ -65,7 +71,6 @@ with DAG('salmon_rnaseq_10x',
          user_defined_macros={'tmp_dir_path' : utils.get_tmp_dir_path}
          ) as dag:
 
- 
     pipeline_name = 'salmon-rnaseq'
     cwl_workflow1 = os.path.join(pipeline_name, 'pipeline.cwl')
     cwl_workflow2 = os.path.join('portal-containers', 'h5ad-to-arrow.cwl')
@@ -108,7 +113,6 @@ with DAG('salmon_rnaseq_10x',
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
-        pipeline_base_dir = str(Path(__file__).resolve().parent / 'cwl')
         cwltool_dir = os.path.dirname(cwltool.__file__)
         while cwltool_dir:
             part1, part2 = os.path.split(cwltool_dir)
@@ -126,7 +130,7 @@ with DAG('salmon_rnaseq_10x',
             '--outdir',
             os.path.join(tmpdir, 'cwl_out'),
             '--parallel',
-            os.path.join(pipeline_base_dir, cwl_workflow1),
+            os.fspath(PIPELINE_BASE_DIR / cwl_workflow1),
             '--fastq_dir',
             data_dir,
             '--threads',
@@ -152,7 +156,6 @@ with DAG('salmon_rnaseq_10x',
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
-        pipeline_base_dir = str(Path(__file__).resolve().parent / 'cwl')
         cwltool_dir = os.path.dirname(cwltool.__file__)
         while cwltool_dir:
             part1, part2 = os.path.split(cwltool_dir)
@@ -166,7 +169,7 @@ with DAG('salmon_rnaseq_10x',
             'env',
             'PATH=%s:%s' % (cwltool_dir, os.environ['PATH']),
             'cwltool',
-            os.path.join(pipeline_base_dir, cwl_workflow2),
+            os.fspath(PIPELINE_BASE_DIR / cwl_workflow2),
             '--input_dir',
             '.'
         ]
@@ -214,7 +217,6 @@ with DAG('salmon_rnaseq_10x',
                      'bail_op' : 'set_dataset_error',
                      'test_op' : 'pipeline_exec'}
         )
-
 
     t_maybe_keep_cwl2 = BranchPythonOperator(
         task_id='maybe_keep_cwl2',
@@ -311,15 +313,15 @@ with DAG('salmon_rnaseq_10x',
             'content-type' : 'application/json'}
         print('headers:')
         pprint(headers)
-        extra_options=[]
-         
+        extra_options = []
+
         http = HttpHook(method,
                         http_conn_id=http_conn_id)
- 
+
         if success:
             md = {}
-            pipeline_base_dir = os.path.join(os.environ['AIRFLOW_HOME'],
-                                             'dags', 'cwl')
+            # Is this necessary? Is it the same as the global PIPELINE_BASE_DIR?
+            pipeline_base_dir = Path(os.environ['AIRFLOW_HOME']) / 'dags/cwl'
             if 'dag_provenance' in kwargs['dag_run'].conf:
                 md['dag_provenance'] = kwargs['dag_run'].conf['dag_provenance'].copy()
                 new_prv_dct = utils.get_git_provenance_dict([__file__,
@@ -338,8 +340,14 @@ with DAG('salmon_rnaseq_10x',
                                                               os.path.join(pipeline_base_dir,
                                                                            cwl_workflow2)]))
                 md['dag_provenance_list'] = dag_prv
+
+            manifest_files = find_pipeline_manifests(
+                pipeline_base_dir / cwl_workflow1,
+                pipeline_base_dir / cwl_workflow2,
+            )
             md.update(utils.get_file_metadata_dict(ds_dir,
-                                                   utils.get_tmp_dir_path(kwargs['run_id'])))
+                                                   utils.get_tmp_dir_path(kwargs['run_id']),
+                                                   manifest_files))
             try:
                 assert_json_matches_schema(md, 'dataset_metadata_schema.yml')
                 data = {'dataset_id' : derived_dataset_uuid,
@@ -391,7 +399,7 @@ with DAG('salmon_rnaseq_10x',
         bash_command='echo rm -r {{tmp_dir_path(run_id)}}',
         trigger_rule='all_success'
         )
- 
+
 
     (dag >> t1 >> t_create_tmpdir
      >> t_send_create_dataset >> t_set_dataset_processing

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -555,8 +555,9 @@ def map_queue_name(raw_queue_name: str) -> str:
     If the configuration contains QUEUE_NAME_TEMPLATE, use it to customize the
     provided queue name.  This allows job separation under Celery.
     """
-    if 'QUEUE_NAME_TEMPLATE' in airflow_conf.as_dict()['connections']:
-        template = airflow_conf.as_dict()['connections']['QUEUE_NAME_TEMPLATE']
+    conf_dict = airflow_conf.as_dict()
+    if 'QUEUE_NAME_TEMPLATE' in conf_dict.get('connections', {}):
+        template = conf_dict['connections']['QUEUE_NAME_TEMPLATE']
         template = template.strip("'").strip('"')  # remove quotes that may be on the config string
         rslt = template.format(raw_queue_name)
         return rslt

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -27,7 +27,7 @@ SCHEMA_BASE_URI = 'http://schemata.hubmapconsortium.org/'
 from airflow.hooks.http_hook import HttpHook
 
 # Some constants
-PIPELINE_BASE_DIR = Path(environ['AIRFLOW_HOME']) / 'pipeline_git_repos'
+PIPELINE_BASE_DIR = Path(__file__).resolve().parent / 'cwl'
 
 # default maximum for number of files for which info should be returned in_line
 # rather than via an alternative scratch file
@@ -159,47 +159,6 @@ def find_pipeline_manifests(*cwl_files: Path) -> List[Path]:
         if manifest_file.is_file():
             manifests.append(manifest_file)
     return manifests
-
-
-def clone_or_update_pipeline(pipeline_name: str, ref: str = 'origin/master') -> None:
-    """
-    Ensure that a Git clone of a specific pipeline exists inside the
-    PIPELINE_BASE_DIR directory.
-
-    If it doesn't exist already, clone it and check out the specified ref.
-    If it already exists, run 'git fetch' inside, then check out the specified ref.
-    With the default ref (origin/master), this will mimic running 'git pull'.
-
-    :param pipeline_name: the name of a public repository on GitHub, under the
-      'hubmapconsortium' organization. The remote repository URL will be constructed
-      as 'https://github.com/hubmapconsortium/{pipeline_name}'.
-    :param ref: which reference to check out in the repository after cloning
-      or fetching. This can be a remote branch (prefixed with 'origin/') or a
-      tag if a pipeline should be pinned to a specific version.
-    """
-    PIPELINE_BASE_DIR.mkdir(parents=True, exist_ok=True)
-    pipeline_dir = PIPELINE_BASE_DIR / pipeline_name
-    if pipeline_dir.is_dir():
-        # Already exists. Fetch and update
-        check_call(GIT_FETCH_COMMAND, cwd=pipeline_dir)
-    else:
-        repository_url = f'https://github.com/hubmapconsortium/{pipeline_name}'
-        clone_command = [
-            piece.format(repository=repository_url)
-            for piece in GIT_CLONE_COMMAND
-        ]
-        check_call(clone_command, cwd=PIPELINE_BASE_DIR)
-
-    # Whether we just cloned the repository or fetched any updates that may
-    # exist, check out the ref given as the argument to this function.
-    # This is required even when cloning, since you can't do (e.g.)
-    #   `git clone -b origin/master whatever-repo`
-
-    checkout_command = [
-        piece.format(ref=ref)
-        for piece in GIT_CHECKOUT_COMMAND
-    ]
-    check_call(checkout_command, cwd=pipeline_dir)
 
 
 def get_git_commits(file_list: StrOrListStr) -> StrOrListStr:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -131,6 +131,7 @@ class PipelineFileMatcher(FileMatcher):
         """
         path_str = fspath(file_path)
         for pattern, description_template, ontology_term in self.matchers:
+            # TODO: walrus operator
             m = pattern.match(path_str)
             if m:
                 formatted_description = description_template.format_map(m.groupdict())
@@ -149,9 +150,9 @@ class DummyFileMatcher(FileMatcher):
 
 def find_pipeline_manifests(*cwl_files: Path) -> List[Path]:
     """
-    Constructs a manifest path from the CWL file (strip '.cwl',
-    append '-manifest.json'), and check whether the manifest exists.
-    If so, return that `Path`. Otherwise, return `None`.
+    Constructs manifest paths from CWL files (strip '.cwl', append
+    '-manifest.json'), and check whether each manifest exists. Return
+    a list of `Path`s that exist on disk.
     """
     manifests = []
     for cwl_file in cwl_files:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -426,7 +426,7 @@ def pythonop_maybe_keep(**kwargs) -> None:
     test_key = kwargs['test_key'] if 'test_key' in kwargs else None
     retcode = int(kwargs['ti'].xcom_pull(task_ids=test_op, key=test_key))
     print('%s key %s: %s\n' % (test_op, test_key, retcode))
-    if retcode is 0:
+    if retcode == 0:
         return kwargs['next_op']
     else:
         return bail_op

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -65,14 +65,14 @@ SHA1SUM_COMMAND = [
     'sha1sum',
     '{fname}'
 ]
-FILE_TYPE_MATCHERS = [('^.*\.csv$', 'csv'),  # format is (regex, type)
-                      ('^.*\.hdf5$', 'hdf5'),
-                      ('^.*\.h5ad$', 'h5ad'),
-                      ('^.*\.pdf$', 'pdf'),
-                      ('^.*\.json$', 'json'),
-                      ('^.*\.arrow$', 'arrow'),
-                      ('(^.*\.fastq$)|(^.*\.fastq.gz$)', 'fastq'),
-                      ('(^.*\.yml$)|(^.*\.yaml$)', 'yaml')
+FILE_TYPE_MATCHERS = [(r'^.*\.csv$', 'csv'),  # format is (regex, type)
+                      (r'^.*\.hdf5$', 'hdf5'),
+                      (r'^.*\.h5ad$', 'h5ad'),
+                      (r'^.*\.pdf$', 'pdf'),
+                      (r'^.*\.json$', 'json'),
+                      (r'^.*\.arrow$', 'arrow'),
+                      (r'(^.*\.fastq$)|(^.*\.fastq.gz$)', 'fastq'),
+                      (r'(^.*\.yml$)|(^.*\.yaml$)', 'yaml')
                       ]
 COMPILED_TYPE_MATCHERS = None
 

--- a/src/ingest-pipeline/schemata/file_info_schema.json
+++ b/src/ingest-pipeline/schemata/file_info_schema.json
@@ -18,6 +18,12 @@
         },
         "filetype": {
           "$ref": "enumerated_types_schema.json#/definitions/file_type"
+        },
+        "description": {
+          "type": "string"
+        },
+        "edam_term": {
+          "type": "string"
         }
       }
     },

--- a/src/ingest-pipeline/schemata/file_info_schema.yml
+++ b/src/ingest-pipeline/schemata/file_info_schema.yml
@@ -13,8 +13,9 @@
         'rel_path': {'type': 'string', 'pattern': '^[^/].+[^/]$'}
         'filetype': {'$ref': 'enumerated_types_schema.yml#/definitions/file_type'}
         'size': {'type': 'integer', 'minimum': 0}
+        'description': {'type': 'string'}
+        'edam_term': {'type': 'string'}
         #'sha1sum': {'type': 'string', 'pattern': '^[a-fA-F0-9]{40}$'}
   'file_info':
     'type': 'array'
     'items': {'$ref': '#/definitions/file_info_record'}
-     

--- a/src/ingest-pipeline/schemata/pipeline_file_manifest.json
+++ b/src/ingest-pipeline/schemata/pipeline_file_manifest.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "http://schemata.hubmapconsortium.org/pipeline_file_manifest.json",
+  "title": "pipeline file manifest schema",
+  "description": "pipeline file manifest schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "pattern": {
+        "type": "string",
+        "description": "Regular expression of relative file paths for pipeline outputs"
+      },
+      "description": {
+        "type": "string",
+        "description": "human-readable description of this pipeline output file"
+      },
+      "edam_ontology_term": {
+        "type": "string",
+        "description": "Term in the EDAM ontology describing this pipeline output file"
+      }
+    }
+  }
+}

--- a/src/ingest-pipeline/schemata/pipeline_file_manifest.yml
+++ b/src/ingest-pipeline/schemata/pipeline_file_manifest.yml
@@ -1,0 +1,17 @@
+'$schema': 'http://json-schema.org/schema#'
+'$id': 'http://schemata.hubmapconsortium.org/pipeline_file_manifest.yml'
+'title': 'pipeline file manifest schema'
+'description': 'pipeline file manifest schema'
+'type': 'array'
+'items':
+  'type': 'object'
+  'properties':
+    'pattern':
+      'type': 'string'
+      'description': 'Regular expression of relative file paths for pipeline outputs'
+    'description':
+      'type': 'string'
+      'description': 'human-readable description of this pipeline output file'
+    'edam_ontology_term':
+      'type': 'string'
+      'description': 'Term in the EDAM ontology describing this pipeline output file'


### PR DESCRIPTION
This PR implements filtering of the data files produced by analysis pipelines, leaving full results on disk but only including selected files in indexes and downstream steps (e.g. the portal UI).