### PR TITLE
Hotfix: read correct ontology term from manifest

### DIFF
--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -113,7 +113,7 @@ class PipelineFileMatcher(FileMatcher):
 
         for annotation in manifest:
             pattern = re.compile(annotation['pattern'])
-            yield pattern, annotation['description'], annotation['type']
+            yield pattern, annotation['description'], annotation['edam_ontology_term']
 
     @classmethod
     def create_from_files(cls, pipeline_file_manifests: Iterable[Path]):


### PR DESCRIPTION
Found this while checking against schemas; this fix was only in a Git stash which happened to be what I tested against.