### PR TITLE
Avoid many DeprecationWarnings from DAGs.

### DIFF
--- a/src/ingest-pipeline/airflow/dags/.airflowignore
+++ b/src/ingest-pipeline/airflow/dags/.airflowignore
@@ -1,5 +1,6 @@
 # This file contains regular expressions identifying contents that should be ignored by Airflow
 mock_data
 cwl
+obsolete
 utils.py
 workflow_map.yml

--- a/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
@@ -43,7 +43,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error),

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -42,7 +42,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)
@@ -311,8 +310,7 @@ with DAG('codex_cytokit',
         cd "$ds_dir" ; \
         tar -xf symlinks.tar ; \
         echo $?
-        """,
-        provide_context=True
+        """
         )
 
 

--- a/src/ingest-pipeline/airflow/dags/devtest_step2.py
+++ b/src/ingest-pipeline/airflow/dags/devtest_step2.py
@@ -38,7 +38,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)
@@ -170,8 +169,7 @@ with DAG('devtest_step2',
         popd ; \
         mv "$tmp_dir"/cwl_out/* "$ds_dir" >> "$tmp_dir/session.log" 2>&1 ; \
         echo $?
-        """,
-        provide_context=True
+        """
         )
 
 

--- a/src/ingest-pipeline/airflow/dags/ingest_vanderbilt.py
+++ b/src/ingest-pipeline/airflow/dags/ingest_vanderbilt.py
@@ -21,7 +21,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
 }
 
@@ -77,8 +76,7 @@ with DAG('ingest_vanderbilt',
 
     t_create_tmpdir = BashOperator(
         task_id='create_temp_dir',
-        bash_command='mkdir ${AIRFLOW_HOME}/data/temp/{{run_id}}',
-        provide_context=True
+        bash_command='mkdir ${AIRFLOW_HOME}/data/temp/{{run_id}}'
         )
 
 
@@ -92,8 +90,7 @@ with DAG('ingest_vanderbilt',
         python $src_dir/metadata_extract.py --out ./rslt.yml --yaml "$lz_dir" \
           > ./session.log 2>&1 ; \
         echo $?
-        """,
-        provide_context = True
+        """
         )
 
 

--- a/src/ingest-pipeline/airflow/dags/mock_ingest_rnaseq_10x.py
+++ b/src/ingest-pipeline/airflow/dags/mock_ingest_rnaseq_10x.py
@@ -20,7 +20,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True
 }
 
 with DAG('mock_ingest_rnaseq_10x', schedule_interval=None, is_paused_upon_creation=False,

--- a/src/ingest-pipeline/airflow/dags/mock_ingest_vanderbilt.py
+++ b/src/ingest-pipeline/airflow/dags/mock_ingest_vanderbilt.py
@@ -20,7 +20,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True
 }
 
 with DAG('mock_ingest_vanderbilt', schedule_interval=None, is_paused_upon_creation=False, default_args=default_args) as dag:

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -47,7 +47,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)
@@ -244,8 +243,7 @@ with DAG('ometiff_pyramid',
     #     cd "$ds_dir" ; \
     #     tar -xf symlinks.tar ; \
     #     echo $?
-    #     """,
-    #     provide_context=True
+    #     """
     #     )
 
     def send_status_msg(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
+++ b/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
@@ -41,7 +41,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
@@ -45,7 +45,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)
@@ -196,8 +195,7 @@ with DAG('salmon_rnaseq_10x',
         cd "$tmp_dir"/cwl_out/cluster-marker-genes ; \
         {{ti.xcom_pull(task_ids='build_cmd2')}} >> $tmp_dir/session.log 2>&1 ; \
         echo $?
-        """,
-        provide_context=True
+        """
     )
 
     t_maybe_keep_cwl1 = BranchPythonOperator(
@@ -251,8 +249,7 @@ with DAG('salmon_rnaseq_10x',
         mkdir cluster-marker-genes ; \
         mv cluster_marker_genes.h5ad cluster-marker-genes ; \
         echo $?
-        """,
-        provide_context=True
+        """
         )
 
     def send_status_msg(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
@@ -45,7 +45,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error),

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_sciseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_sciseq.py
@@ -45,7 +45,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)
@@ -197,8 +196,7 @@ with DAG('salmon_rnaseq_sciseq',
         cd "$tmp_dir"/cwl_out/cluster-marker-genes ; \
         {{ti.xcom_pull(task_ids='build_cmd2')}} >> $tmp_dir/session.log 2>&1 ; \
         echo $?
-        """,
-        provide_context=True
+        """
     )
 
     t_maybe_keep_cwl1 = BranchPythonOperator(
@@ -252,8 +250,7 @@ with DAG('salmon_rnaseq_sciseq',
         mkdir cluster-marker-genes ; \
         mv cluster_marker_genes.h5ad cluster-marker-genes ; \
         echo $?
-        """,
-        provide_context=True
+        """
         )
 
     def send_status_msg(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_snareseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_snareseq.py
@@ -45,7 +45,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)
@@ -196,8 +195,7 @@ with DAG('salmon_rnaseq_snareseq',
         cd "$tmp_dir"/cwl_out/cluster-marker-genes ; \
         {{ti.xcom_pull(task_ids='build_cmd2')}} >> $tmp_dir/session.log 2>&1 ; \
         echo $?
-        """,
-        provide_context=True
+        """
     )
 
     t_maybe_keep_cwl1 = BranchPythonOperator(
@@ -251,8 +249,7 @@ with DAG('salmon_rnaseq_snareseq',
         mkdir cluster-marker-genes ; \
         mv cluster_marker_genes.h5ad cluster-marker-genes ; \
         echo $?
-        """,
-        provide_context=True
+        """
         )
 
     def send_status_msg(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq_sci.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq_sci.py
@@ -45,7 +45,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error),
@@ -167,8 +166,7 @@ with DAG(
         cd "$tmp_dir"/cwl_out ; \
         {{ti.xcom_pull(task_ids='build_cmd2')}} >> $tmp_dir/session.log 2>&1 ; \
         echo $?
-        """,
-        provide_context=True,
+        """
     )
 
     t_maybe_keep_cwl1 = BranchPythonOperator(

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq_snare.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq_snare.py
@@ -45,7 +45,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error),
@@ -167,8 +166,7 @@ with DAG(
         cd "$tmp_dir"/cwl_out ; \
         {{ti.xcom_pull(task_ids='build_cmd2')}} >> $tmp_dir/session.log 2>&1 ; \
         echo $?
-        """,
-        provide_context=True,
+        """
     )
 
     t_maybe_keep_cwl1 = BranchPythonOperator(

--- a/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
+++ b/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
@@ -36,7 +36,6 @@ default_args = {
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
-    'provide_context': True,
     'xcom_push': True,
     'queue': utils.map_queue_name('general'),
     'on_failure_callback': utils.create_dataset_state_error_callback(get_dataset_uuid)    
@@ -143,8 +142,7 @@ with DAG('scan_and_begin_processing',
         python $src_dir/metadata_extract.py --out ./rslt.yml --yaml "$lz_dir" \
           > ./session.log 2>&1 ; \
         echo $?
-        """,
-        provide_context = True
+        """
         )
 
     t_md_consistency_tests = PythonOperator(
@@ -162,8 +160,7 @@ with DAG('scan_and_begin_processing',
 
     t_create_tmpdir = BashOperator(
         task_id='create_temp_dir',
-        bash_command='mkdir {{tmp_dir_path(run_id)}}',
-        provide_context=True
+        bash_command='mkdir {{tmp_dir_path(run_id)}}'
         )
 
 

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -490,9 +490,10 @@ def pythonop_send_create_dataset(**kwargs) -> str:
         dataset_types = kwargs['dataset_types']
     else:
         dataset_types = kwargs['dataset_types_callable'](**kwargs)
+    dataset_name = kwargs['dataset_name_callable'](**kwargs)
     data = {
         "source_dataset_uuid": kwargs['parent_dataset_uuid_callable'](**kwargs),
-        "derived_dataset_name": kwargs['dataset_name_callable'](**kwargs),
+        "derived_dataset_name": dataset_name,
         "derived_dataset_types": dataset_types
     }
     print('data: ')

--- a/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
@@ -15,14 +15,12 @@ from utils import (
 
 class LogInfoOperator(PythonOperator):
     @apply_defaults
-    def __init__(self, *args, **kwargs):
-        print('args follow')
-        pprint(args)
-        print('kwargs follow')
-        pprint(kwargs)
+    def __init__(self, **kwargs):
+        #print('kwargs follow')
+        #pprint(kwargs)
         super().__init__(python_callable=pythonop_trigger_target,
                          provide_context=True,
-                         *args, **kwargs)
+                         **kwargs)
     
 
 class JoinOperator(DummyOperator):


### PR DESCRIPTION
This avoids many deprecation warnings each time the dags are scanned, mainly by not sending 'provide_context=True' to BashOperators.

Also added the 'obsolete' subdir to dags/.gitignore