### PR TITLE
Update ome-tiff-pyramid for IMS: allow arbitrary downsampling types from the DAG

### DIFF
--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -34,6 +34,9 @@ from utils import (
     decrypt_tok
 )
 
+# Passed directly to the pipeline
+DOWNSAMPLE_TYPE = 'CUBIC'
+
 # after running this DAG you should have on disk
 # 1. 1 OME.TIFF pyramid per OME.TIFF in the original dataset
 # 2. 1 .N5 file per OME.TIFF in the original dataset
@@ -96,8 +99,10 @@ with DAG('ometiff_pyramid_ims',
         command = [
             *get_cwltool_base_cmd(tmpdir),
             os.fspath(PIPELINE_BASE_DIR / cwl_workflow1),
+            '--downsample_type',
+            DOWNSAMPLE_TYPE,
             '--ometiff_directory',
-            data_dir
+            data_dir,
         ]
 
         command_str = ' '.join(shlex.quote(piece) for piece in command)


### PR DESCRIPTION
Version 1.3 of the `ome-tiff-pyramid` pipeline exposes downsample type as an option to the user. Update the `ome-tiff-pyramid-ims` submodule to use this version and set `DOWNSAMPLE_TYPE = 'CUBIC'` in the `ometiff_pyramid_ims` DAG.

This should allow for experiments with other downsample types via local modifications of the DAG.