### PR TITLE
codex_cytokit DAG: fix build_cwltool_cmd2

### DIFF
--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -132,7 +132,7 @@ with DAG('codex_cytokit',
         print('tmpdir: ', tmpdir)
         parent_data_dir = ctx['parent_lz_path']
         print('parent_data_dir: ', parent_data_dir)
-        data_dir = os.path.join(tmpdir, 'cwl_out')  # This stage reads input from stage 1
+        data_dir = tmpdir / 'cwl_out'
         print('data_dir: ', data_dir)
 
         command = [


### PR DESCRIPTION
I introduced a bug in 2d1e5b4ead70ed8f28689d53a8eae91610c132ad, due to bit rot in rebasing that commit too many times.

Fix trying to use a `str` path like a `Path` object.