### PR TITLE
Return Path objects from utils.get_tmp_dir_path

### DIFF
--- a/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
@@ -71,7 +71,7 @@ with DAG(
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
 
         data_dirs = ctx['parent_lz_path']
         data_dirs = [data_dirs] if isinstance(data_dirs, str) else data_dirs

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -76,7 +76,7 @@ with DAG('codex_cytokit',
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
@@ -128,7 +128,7 @@ with DAG('codex_cytokit',
     def build_cwltool_cmd2(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         parent_data_dir = ctx['parent_lz_path']
         print('parent_data_dir: ', parent_data_dir)
@@ -179,7 +179,7 @@ with DAG('codex_cytokit',
     def build_cwltool_cmd3(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         parent_data_dir = ctx['parent_lz_path']
         print('parent_data_dir: ', parent_data_dir)

--- a/src/ingest-pipeline/airflow/dags/devtest_step2.py
+++ b/src/ingest-pipeline/airflow/dags/devtest_step2.py
@@ -65,7 +65,7 @@ with DAG('devtest_step2',
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         #print('tmpdir: ', tmpdir)
         tmp_subdir = os.path.join(tmpdir, 'cwl_out')
         #print('tmp_subdir: ', tmp_subdir)

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -86,7 +86,7 @@ with DAG('ometiff_pyramid',
         run_id = kwargs['run_id']
 
         #tmpdir is temp directory in /hubmap-tmp
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
 
         #data directory is input directory in /hubmap-data
@@ -130,7 +130,7 @@ with DAG('ometiff_pyramid',
         run_id = kwargs['run_id']
 
         #tmpdir is temp directory in /hubmap-tmp
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
 
         #get data directory

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -89,7 +89,7 @@ with DAG('ometiff_pyramid_ims',
         run_id = kwargs['run_id']
 
         #tmpdir is temp directory in /hubmap-tmp
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
 
         #data directory is input directory in /hubmap-data
@@ -135,7 +135,7 @@ with DAG('ometiff_pyramid_ims',
         run_id = kwargs['run_id']
 
         #tmpdir is temp directory in /hubmap-tmp
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
 
         #get data directory

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_10x.py
@@ -92,7 +92,7 @@ with DAG('salmon_rnaseq_10x',
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
@@ -115,7 +115,7 @@ with DAG('salmon_rnaseq_10x',
     def build_cwltool_cmd2(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
@@ -73,7 +73,7 @@ with DAG(
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         data_dir = ctx['parent_lz_path']
 
         command = [

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_sciseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_sciseq.py
@@ -92,7 +92,7 @@ with DAG('salmon_rnaseq_sciseq',
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
@@ -116,7 +116,7 @@ with DAG('salmon_rnaseq_sciseq',
     def build_cwltool_cmd2(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_snareseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_snareseq.py
@@ -81,7 +81,7 @@ with DAG('salmon_rnaseq_snareseq',
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
 
         data_dirs = ctx['parent_lz_path']
@@ -108,7 +108,7 @@ with DAG('salmon_rnaseq_snareseq',
     def build_cwltool_cmd2(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq_sci.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq_sci.py
@@ -79,7 +79,7 @@ with DAG(
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
@@ -101,7 +101,7 @@ with DAG(
     def build_cwltool_cmd2(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq_sn.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq_sn.py
@@ -79,7 +79,7 @@ with DAG(
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)
@@ -101,7 +101,7 @@ with DAG(
     def build_cwltool_cmd2(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq_snare.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq_snare.py
@@ -80,7 +80,7 @@ with DAG(
     def build_cwltool_cmd1(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dirs = ctx['parent_lz_path']
         data_dirs = [data_dirs] if isinstance(data_dirs, str) else data_dirs
@@ -104,7 +104,7 @@ with DAG(
     def build_cwltool_cmd2(**kwargs):
         ctx = kwargs['dag_run'].conf
         run_id = kwargs['run_id']
-        tmpdir = Path(utils.get_tmp_dir_path(run_id))
+        tmpdir = utils.get_tmp_dir_path(run_id)
         print('tmpdir: ', tmpdir)
         data_dir = ctx['parent_lz_path']
         print('data_dir: ', data_dir)

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -696,7 +696,7 @@ def pythonop_md_consistency_tests(**kwargs) -> int:
     else:
         return 0
 
-def _get_scratch_base_path() -> str:
+def _get_scratch_base_path() -> Path:
     dct = airflow_conf.as_dict(display_sensitive=True)['connections']
     if 'WORKFLOW_SCRATCH' in dct:
         scratch_path = dct['WORKFLOW_SCRATCH']
@@ -707,14 +707,14 @@ def _get_scratch_base_path() -> str:
     else:
         raise KeyError('WORKFLOW_SCRATCH')  # preserve original code behavior
     scratch_path = scratch_path.strip("'").strip('"')  # remove quotes that may be on the string
-    return scratch_path
+    return Path(scratch_path)
 
 
-def get_tmp_dir_path(run_id: str) -> str:
+def get_tmp_dir_path(run_id: str) -> Path:
     """
     Given the run_id, return the path to the dag run's scratch directory
     """
-    return join(_get_scratch_base_path(), run_id)
+    return _get_scratch_base_path() / run_id
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
This is much nicer than wrapping every call to this function in `Path(...)` -- I had done the latter to avoid breaking things with other usage of `get_tmp_dir_path` that I wasn't aware of.