### PR TITLE
Add a schema to launch_multi_analysis DAG

### DIFF
--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -56,7 +56,15 @@ with DAG('launch_multi_analysis',
     def check_uuids(**kwargs):
         print('dag_run conf follows:')
         pprint(kwargs['dag_run'].conf)
-        # uuid_l = ['HBM959.DHDL.956','3e337deec405743f52347a8d526931f0', 'foo'] # get from conf
+
+        try:
+            assert_json_matches_schema(kwargs['dag_run'].conf,
+                                       'launch_multi_metadata_schema.yml')
+        except AssertionError as e:
+            print('invalid metadata follows:')
+            pprint(kwargs['dag_run'].conf)
+            raise
+        
         uuid_l = kwargs['dag_run'].conf['uuid_list']
         collection_type = kwargs['dag_run'].conf['collection_type']
         filtered_uuid_l = []

--- a/src/ingest-pipeline/schemata/launch_multi_metadata_schema.yml
+++ b/src/ingest-pipeline/schemata/launch_multi_metadata_schema.yml
@@ -1,0 +1,23 @@
+'$schema': 'http://json-schema.org/schema#'
+'$id': 'http://schemata.hubmapconsortium.org/launch_multi_metadata_schema.yml'
+'title': 'launch_multi_analysis metadata schema'
+'description': 'launch_multi_analysis metadata schema'
+
+'allOf': [{'$ref': '#/definitions/launch_multi_metadata'}]
+
+'definitions':
+
+  'launch_multi_metadata':
+     'type': 'object'
+     'properties':
+        'collection_type':
+          'type': 'string'
+          'description': 'a data collection type, e.g. "rnaseq_10x"'
+        'uuid_list':
+          'type': 'array'
+          'items':
+            'type': 'string'
+            'description': 'a dataset uuid or DOI'
+          'minItems': 1
+     'required': ['uuid_list', 'collection_type']
+    


### PR DESCRIPTION
Multi-dataset analyses are currently started manually, by triggering the launch_multi_analysis DAG with a JSON string specifying the input datasets and the analysis.  This PR adds schema testing to the dag so that errors in that JSON string can produce sensible messages.