### PR TITLE
Airflow was being included by regenerate_venv; moved to requirements.…

### DIFF
--- a/src/ingest-pipeline/misc/tools/regenerate_venv.sh
+++ b/src/ingest-pipeline/misc/tools/regenerate_venv.sh
@@ -38,7 +38,6 @@ scl enable rh-python36 bash <<EOF
   virtualenv --prompt=\(${label}\) venv
   . venv/bin/activate
   pip install --upgrade pip
-  pip install 'apache-airflow[celery,crypto,postgres,redis,ssh]'
   pip install -r ingest-pipeline/src/ingest-pipeline/requirements.txt
 
 EOF

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -5,6 +5,7 @@ pylibczi>=1.1.1
 tifffile
 xmltodict>=0.12.0
 pyimzml>=1.2.6
+apache-airflow[celery,crypto,postgres,redis,ssh]<2.0.0
 airflow-multi-dagrun>=1.2
 jsonschema==3.2.0
 fastjsonschema==2.14.2


### PR DESCRIPTION
…txt and added version constraint

The first time we regenerated the venv after the release of Airflow 2.0, we found that there was nothing constraining the install from upgrading to the new version.  This places the constraint directly in requirements.txt .