### PR TITLE
CODEX: fix ome-tiff-offsets invocation with stitched images

### DIFF
--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -235,7 +235,7 @@ with DAG('codex_cytokit',
             *get_cwltool_base_cmd(tmpdir),
             cwl_workflows['ome_tiff_offsets'],
             '--input_dir',
-            data_dir / 'output/extract/expressions/ome-tiff',
+            data_dir / 'stitched/expressions',
         ]
 
         return join_quote_command_str(command)


### PR DESCRIPTION
This fixes the recent DAG failure detailed in `/hive/hubmap-test/data/consortium/University of Florida TMC/06450be425add16df5de7286d93d34d0/session.log`.