### PR TITLE
Try to canonicalize assay type using TypeClient before lookup in work…

### DIFF
--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -566,7 +566,7 @@ def pythonop_send_create_dataset(**kwargs) -> str:
     data = {
         "source_dataset_uuid": kwargs['parent_dataset_uuid_callable'](**kwargs),
         "derived_dataset_name": dataset_name,
-        "derived_dataset_types": dataset_types
+        "derived_dataset_types": _canonicalize_assay_type_if_possible(dataset_types)
     }
     print('data:')
     pprint(data)
@@ -1068,6 +1068,22 @@ def _get_type_client() -> TypeClient:
     return TYPE_CLIENT
 
 
+def _canonicalize_assay_type_if_possible(assay_type: StrOrListStr) -> StrOrListStr:
+    """
+    Attempt to look up the the assay type (or each element if it is a list) and
+    return the canonical version.
+    """
+    if isinstance(assay_type, list):
+        return [_canonicalize_assay_type_if_possible(elt) for elt in assay_type]
+    else:
+        try:
+            type_info = _get_type_client().getAssayType(assay_type)
+            assay_type = type_info.name
+        except Exception:
+            pass
+        return assay_type
+
+
 def downstream_workflow_iter(collectiontype: str, assay_type: StrOrListStr) -> Iterable[str]:
     """
     Returns an iterator over zero or more workflow names matching the given
@@ -1075,12 +1091,7 @@ def downstream_workflow_iter(collectiontype: str, assay_type: StrOrListStr) -> I
     a known workflow, e.g. an Airflow DAG implemented by workflow_name.py .
     """
     collectiontype = collectiontype or ''
-    # Canonicalize the assay type if possible
-    try:
-        type_info = _get_type_client().getAssayType(assay_type)
-        assay_type = type_info.name
-    except Exception:
-        pass
+    assay_type = _canonicalize_assay_type_if_possible(assay_type)
     assay_type = assay_type or ''
     for ct_re, at_re, workflow in _get_workflow_map():
         if isinstance(assay_type, str):

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1063,7 +1063,7 @@ def _get_type_client() -> TypeClient:
         if conn.port is None:
             url = f'{conn.conn_type}://{conn.host}'
         else:
-            url = f'{conn.type}://{conn.host}:{conn.port}'
+            url = f'{conn.conn_type}://{conn.host}:{conn.port}'
         TYPE_CLIENT = TypeClient(url)
     return TYPE_CLIENT
 

--- a/src/ingest-pipeline/airflow/plugins/hubmap_api/endpoint.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_api/endpoint.py
@@ -43,6 +43,7 @@ airflow_conf.read(os.path.join(os.environ['AIRFLOW_HOME'], 'instance', 'app.cfg'
 NEEDED_ENV_VARS = [
     'AIRFLOW_CONN_INGEST_API_CONNECTION',
     'AIRFLOW_CONN_UUID_API_CONNECTION',
+    'AIRFLOW_CONN_SEARCH_API_CONNECTION',
     ]
 NEEDED_CONFIG_SECTIONS = [
     'ingest_map',


### PR DESCRIPTION
…flow_map

Historically the assay type found in the metadata has been used 'raw' during lookup in workflow_map.yaml to determine which workflow(s) to use for downstream processing.  This PR adds canonicalization via hubmap_commons.type_client.TypeClient .