### PR TITLE
Jpuerto/airflow globus auth groups

### DIFF
--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -128,7 +128,7 @@ class GlobusAuthBackend(object):
                 email = user_info['email']
                 group_ids = user_info['hmgroupids']
 
-                if group_ids is None or list(set(group_ids) & set(self.group_uuids)) is None:
+                if not (group_ids and list(set(group_ids) & set(self.group_uuids))):
                     raise Exception('User does not have correct group assignments')
 
                 user = session.query(models.User).filter(

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -95,7 +95,8 @@ class GlobusAuthBackend(object):
         else:
             self.authHelper = AuthHelper.instance()
 
-        groups_with_permission_by_name = get_config_param('hubmap_groups').split(',')
+        groups_with_permission_by_name = [group.strip().lower() for group in get_config_param('hubmap_groups').split(',')]
+
         groups_by_name = AuthHelper.getHuBMAPGroupInfo()
 
         for group_with_permission in groups_with_permission_by_name:

--- a/src/ingest-pipeline/instance/app.cfg.example
+++ b/src/ingest-pipeline/instance/app.cfg.example
@@ -40,7 +40,7 @@ app_client_secret =
 oauth_callback_route = /login
 # If you are running localhost, set this to http. Otherwise, set this to https.
 scheme = https
-# Should be a CSV of group names (lowercase, not quote wrapped) that you would like to give access to
+# Should be a CSV of group names (not quote wrapped) that you would like to give access to
 # EX: group_1, group_2
 hubmap_groups = hubmap-data-admin, hubmap-data-curator
 

--- a/src/ingest-pipeline/instance/app.cfg.example
+++ b/src/ingest-pipeline/instance/app.cfg.example
@@ -40,6 +40,9 @@ app_client_secret =
 oauth_callback_route = /login
 # If you are running localhost, set this to http. Otherwise, set this to https.
 scheme = https
+# Should be a CSV of group names (lowercase, not quote wrapped) that you would like to give access to
+# EX: group_1, group_2
+hubmap_groups = hubmap-data-admin, hubmap-data-curator
 
 [webserver]
 auth_backend = globus_auth.globus_auth


### PR DESCRIPTION
**What I Did:**
Modified the globus authentication for users to include checks for HubMap group assignments.

**Why I Did It:**
To allow for more fine-grained permission control. This also stops any user, with a Globus account, from being able to get in to the system.

**How To Test:**
Go to https://hivevm191.psc.edu:5555 and attempt to log in. You should be able to access the system as long as you are a part of either hubmap-data-admin or hubmap-data-curator.

**Migration Notes:**
This change relies on a new cfg variable (hubmap_groups) under the [Globus] dictionary under app.cfg. This should be a non-quote wrapped CSV of the hubmap group names that should be granted access to the Airflow UI.

This change **also** relies on new changes introduced by @shirey on hubmap-commons.
