### PR TITLE
Avoid duplicate rows when merging in new_dataset_survey.py

### DIFF
--- a/src/ingest-pipeline/misc/tools/new_dataset_survey.py
+++ b/src/ingest-pipeline/misc/tools/new_dataset_survey.py
@@ -108,7 +108,7 @@ def _merge_note_pair(row):
 
 
 def join_notes(df, notes_df):
-    df = pd.merge(df, notes_df[['uuid', 'note']], on='uuid', how='left')
+    df = pd.merge(df, notes_df[['uuid', 'note']].drop_duplicates(), on='uuid', how='left')
     assert 'note_x' in df.columns and 'note_y' in df.columns, "cannot find the notes to merge"
     note_df = df[['note_x', 'note_y']].astype(str)
     df['note'] = note_df.apply(_merge_note_pair, axis=1)
@@ -196,7 +196,7 @@ def main():
                                                     'qa_child_data_type':'derived_data_type',
                                                     'qa_child_status':'derived_status'})
     if in_df is not None:
-        out_df = out_df.merge(in_df, left_on='uuid', right_on=uuid_key)
+        out_df = out_df.drop_duplicates().merge(in_df.drop_duplicates(), left_on='uuid', right_on=uuid_key)
 
     # Some cleanup on out_df before we save it
     drop_list = []


### PR DESCRIPTION
Small mods to src/ingest-pipeline/misc/tools/new_dataset_survey.py to avoid proliferation of identical lines.  Basically, lines were getting duplicated in Pandas 'merge' operations, and then when the spreadsheet was re-used to provide notes for the next generation version those duplicated lines were duplicated again, etc.