### PR TITLE
Jpuerto/globus s3 transfer

### DIFF
--- a/src/ingest-pipeline/airflow/dags/globus_transfer.py
+++ b/src/ingest-pipeline/airflow/dags/globus_transfer.py
@@ -18,14 +18,14 @@ with DAG('globus_transfer', schedule_interval=None, is_paused_upon_creation=Fals
     def perform_transfer(*argv, **kwargs):
         dag_run_conf = kwargs['dag_run'].conf
         globus_transfer_token = dag_run_conf['tokens']['transfer.api.globus.org']['access_token']
-        hive_epid = 'ff1bd56e-2e65-4ec9-86fa-f79422884e96'
-        aws_epid = '1c652c81-3833-4af2-a0b1-01c70805a87d'
+        src_epid = 'ff1bd56e-2e65-4ec9-86fa-f79422884e96'
+        dest_epid = 'bcc55f9a-63d3-4c05-8da4-7eaa4d215f33'
         authorizer = globus_sdk.AccessTokenAuthorizer(globus_transfer_token)
         tc = globus_sdk.TransferClient(authorizer=authorizer)
-        tc.endpoint_autoactivate(hive_epid)
-        tc.endpoint_autoactivate(aws_epid)
+        tc.endpoint_autoactivate(src_epid)
+        tc.endpoint_autoactivate(dest_epid)
 
-        td = globus_sdk.TransferData(tc, hive_epid, aws_epid, label='Transfer')
+        td = globus_sdk.TransferData(tc, src_epid, dest_epid, label='Transfer')
 
         for transfer_item in dag_run_conf['conf']['transfer_items']:
             try:

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -25,7 +25,6 @@ def get_config_param(param):
 
 
 class GlobusUser(models.User):
-
     def __init__(self, user):
         self.user = user
 
@@ -64,7 +63,6 @@ class AuthenticationError(Exception):
 class GlobusAuthBackend(object):
 
     def __init__(self):
-        # self.globus_host = get_config_param('host')
         self.login_manager = flask_login.LoginManager()
         self.login_manager.login_view = 'airflow.login'
         self.flask_app = None
@@ -89,6 +87,9 @@ class GlobusAuthBackend(object):
         self.flask_app.add_url_rule('/login',
                                     'login',
                                     self.login)
+        self.flask_app.add_url_rule('/logout',
+                                    'logout',
+                                    self.logout)
 
         if not AuthHelper.isInitialized():
             self.authHelper = AuthHelper.create(clientId=client_id, clientSecret=client_secret)
@@ -163,7 +164,7 @@ class GlobusAuthBackend(object):
         session.clear()
 
         # the return redirection location to give to Globus Auth
-        redirect_uri = url_for('admin.index', _external=True)
+        redirect_uri = url_for('admin.index', _external=True, _scheme=get_config_param('scheme'))
 
         # build the logout URI with query params
         # there is no tool to help build this (yet!)
@@ -172,7 +173,7 @@ class GlobusAuthBackend(object):
                 '?client={}'.format(
                     get_config_param(['APP_CLIENT_ID'])) +
                 '&redirect_uri={}'.format(redirect_uri) +
-                '&redirect_name=Globus Example App')
+                '&redirect_name=Airflow Home')
 
         # Redirect the user to the Globus Auth logout page
         logout_user()

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -153,9 +153,10 @@ class GlobusAuthBackend(object):
             log.error(e)
             return redirect(url_for('airflow.noaccess'))
 
+    @provide_session
     def logout(self, session=None):
         # Revoke the tokens with Globus Auth
-        log.debug('In the logout routine')
+        log.error('In the logout routine')
         if 'tokens' in f_session:
             for token in (token_info['access_token']
                           for token_info in f_session['tokens'].values()):

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -198,5 +198,5 @@ login_manager = GlobusAuthBackend()
 def login(self, request):
     return login_manager.login(request)
 
-def logout_user(self, request):
-    return login_manager.logout(request)
+def logout_user():
+    return login_manager.logout()

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -155,7 +155,7 @@ class GlobusAuthBackend(object):
 
     def logout(self, session=None):
         # Revoke the tokens with Globus Auth
-        print('in the logout routine')
+        log.debug('In the logout routine')
         if 'tokens' in f_session:
             for token in (token_info['access_token']
                           for token_info in f_session['tokens'].values()):

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -4,7 +4,7 @@ import globus_sdk
 
 # Need to expose these downstream
 # flake8: noqa: F401
-from flask_login import current_user, logout_user, login_required, login_user
+from flask_login import current_user, login_required, login_user
 
 from flask import url_for, redirect, request
 from flask import session as f_session
@@ -178,7 +178,7 @@ class GlobusAuthBackend(object):
                 '&redirect_name=Airflow Home')
 
         # Redirect the user to the Globus Auth logout page
-        logout_user()
+        flask_login.logout_user()
         return redirect(globus_logout_url)
 
     def get_globus_user_profile_info(self, token):
@@ -198,5 +198,5 @@ login_manager = GlobusAuthBackend()
 def login(self, request):
     return login_manager.login(request)
 
-def logout(self, request):
+def logout_user(self, request):
     return login_manager.logout(request)

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -4,7 +4,7 @@ import globus_sdk
 
 # Need to expose these downstream
 # flake8: noqa: F401
-from flask_login import current_user, login_required, login_user
+from flask_login import current_user, login_required, login_user, logout_user
 
 from flask import url_for, redirect, request
 from flask import session as f_session
@@ -175,7 +175,7 @@ class GlobusAuthBackend(object):
                 '&redirect_name=Airflow Home')
 
         # Redirect the user to the Globus Auth logout page
-        flask_login.logout_user()
+        logout_user()
         return redirect(globus_logout_url)
 
     def get_globus_user_profile_info(self, token):
@@ -195,5 +195,5 @@ login_manager = GlobusAuthBackend()
 def login(self, request):
     return login_manager.login(request)
 
-def logout_user():
+def logout():
     return login_manager.logout()

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -87,9 +87,6 @@ class GlobusAuthBackend(object):
         self.flask_app.add_url_rule('/login',
                                     'login',
                                     self.login)
-        self.flask_app.add_url_rule('/logout',
-                                    'logout',
-                                    self.logout)
 
         if not AuthHelper.isInitialized():
             self.authHelper = AuthHelper.create(clientId=client_id, clientSecret=client_secret)
@@ -163,7 +160,7 @@ class GlobusAuthBackend(object):
                 self.globus_oauth.oauth2_revoke_token(token)
 
         # Destroy the session state
-        session.clear()
+        f_session.clear()
 
         # the return redirection location to give to Globus Auth
         redirect_uri = url_for('admin.index', _external=True, _scheme=get_config_param('scheme'))
@@ -173,7 +170,7 @@ class GlobusAuthBackend(object):
         globus_logout_url = (
                 'https://auth.globus.org/v2/web/logout' +
                 '?client={}'.format(
-                    get_config_param(['APP_CLIENT_ID'])) +
+                    get_config_param('APP_CLIENT_ID')) +
                 '&redirect_uri={}'.format(redirect_uri) +
                 '&redirect_name=Airflow Home')
 

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth.py
@@ -155,9 +155,10 @@ class GlobusAuthBackend(object):
 
     def logout(self, session=None):
         # Revoke the tokens with Globus Auth
-        if 'tokens' in session:
+        print('in the logout routine')
+        if 'tokens' in f_session:
             for token in (token_info['access_token']
-                          for token_info in session['tokens'].values()):
+                          for token_info in f_session['tokens'].values()):
                 self.globus_oauth.oauth2_revoke_token(token)
 
         # Destroy the session state

--- a/src/ingest-pipeline/airflow/plugins/hubmap_api/__init__.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_api/__init__.py
@@ -5,6 +5,7 @@ from hubmap_api.manager import aav2 as hubmap_api_admin_v2
 from hubmap_api.manager import aav3 as hubmap_api_admin_v3
 from hubmap_api.manager import aav4 as hubmap_api_admin_v4
 from hubmap_api.manager import aav5 as hubmap_api_admin_v5
+from hubmap_api.manager import aav6 as hubmap_api_admin_v6
 from hubmap_api.manager import blueprint as hubmap_api_blueprint
 
 class AirflowHuBMAPPlugin(AirflowPlugin):
@@ -15,7 +16,7 @@ class AirflowHuBMAPPlugin(AirflowPlugin):
     executors = []
     macros = []
     admin_views = [hubmap_api_admin_v1, hubmap_api_admin_v2, hubmap_api_admin_v3,
-                   hubmap_api_admin_v4, hubmap_api_admin_v5]
+                   hubmap_api_admin_v4, hubmap_api_admin_v5, hubmap_api_admin_v6]
     flask_blueprints = [hubmap_api_blueprint]
     menu_links = []
     appbuilder_views = []

--- a/src/ingest-pipeline/airflow/plugins/hubmap_api/manager.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_api/manager.py
@@ -4,7 +4,7 @@ import json
 
 from werkzeug.exceptions import NotFound
 
-from flask import Blueprint, current_app, send_from_directory, abort, escape, render_template, request
+from flask import Blueprint, current_app, send_from_directory, abort, escape, render_template, request, redirect, url_for
 from flask_admin import BaseView, expose
 from flask import session as f_session
 
@@ -96,6 +96,7 @@ class APIAdminView5(BaseView):
             conf=run_conf,
             external_trigger=True
         )
+        return redirect(url_for('admin.index'))
 aav5 = APIAdminView5(category='HuBMAP API', name="Trigger Test Globus Transfer")
 
 

--- a/src/ingest-pipeline/airflow/plugins/hubmap_api/manager.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_api/manager.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import json
+import airflow
 
 from werkzeug.exceptions import NotFound
 
@@ -98,6 +99,14 @@ class APIAdminView5(BaseView):
         )
         return redirect(url_for('admin.index'))
 aav5 = APIAdminView5(category='HuBMAP API', name="Trigger Test Globus Transfer")
+
+
+class APIAdminView6(BaseView):
+    @expose('/', methods=['GET'])
+    def api_admin_view5(self):
+        LOGGER.info('Triggering Globus Logout routine')
+        return airflow.login.logout()
+aav6 = APIAdminView6(category='HuBMAP API', name="Globus Logout")
 
 
 # Create a Flask blueprint to hold the HuBMAP API


### PR DESCRIPTION
What I Did:
- Modified the globus transfer DAG to use the test S3 bucket endpoint
- Modified the page for the globus transfer to redirect to the index rather than erroring out
- Added a log-out button to allow users to actually log-out of airflow/globus

Why I Did It:
- In preparation for AWS metrics, the DAG needed to be updated to allow for transfer to the S3 bucket
- Logout functionality was added since I was already in airflow development

Migration Notes:
N/A