### PR TITLE
Change lightsheet regex in workflow_map to match a broader range of s…

### DIFF
--- a/src/ingest-pipeline/airflow/dags/workflow_map.yml
+++ b/src/ingest-pipeline/airflow/dags/workflow_map.yml
@@ -54,7 +54,7 @@ workflow_map:
     'assay_type': '3D Imaging Mass Cytometry'
     'workflow': 'ometiff_pyramid'
   - 'collection_type': '.*'
-    'assay_type': 'Light Sheet'
+    'assay_type': '([Ll]ight)( *)([Ss]heet)'
     'workflow': 'ometiff_pyramid'
   - 'collection_type': '.*'
     'assay_type': 'seqFISH'


### PR DESCRIPTION
…trings

Until assay type names get fully standardized, we need to recognize metadata assay_type entries like 'Light Sheet' and 'lightsheet' as both meaning the same assay type.  This PR modifies a regex in workflow_map.yml to make that change.