### PR TITLE
Register thumbnail image

### DIFF
--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -936,9 +936,10 @@ def make_send_status_msg_function(
             ###################################################################################
             # Added by Zhou 6/16/2021 for registering thumbnail image
             dataset_dir_abs_path = dataset_lz_path_fun(**kwargs)
-            thumbnail_image_abs_path = join(dataset_dir_abs_path, 'extra/thumbnail.jpg')
-            if exists(thumbnail_image_abs_path):
-                 md['thumbnail_image_abs_path'] = thumbnail_image_abs_path
+            # This is the only place that uses this hardcoded extra/thumbnail.jpg
+            thumbnail_file_abs_path = join(dataset_dir_abs_path, 'extra/thumbnail.jpg')
+            if exists(thumbnail_file_abs_path):
+                 md['thumbnail_file_abs_path'] = thumbnail_file_abs_path
             ###################################################################################
 
             manifest_files = find_pipeline_manifests(cwl_workflows)

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -936,7 +936,7 @@ def make_send_status_msg_function(
             ###################################################################################
             # Added by Zhou 6/16/2021 for registering thumbnail image
             dataset_full_path = dataset_lz_path_fun(**kwargs)
-            thumbnail_image_full_path = os.path.join(dataset_full_path, 'extra/thumbnail.jpg')
+            thumbnail_image_full_path = join(dataset_full_path, 'extra/thumbnail.jpg')
             if exists(thumbnail_image_full_path):
                  md['thumbnail_image'] = thumbnail_image_full_path
             ###################################################################################

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -932,6 +932,14 @@ def make_send_status_msg_function(
 
             if metadata_fun:
                 md['metadata'] = metadata_fun(**kwargs)
+                
+            ###################################################################################
+            # Added by Zhou 6/16/2021 for registering thumbnail image
+            dataset_full_path = dataset_lz_path_fun(**kwargs)
+            thumbnail_image_full_path = os.path.join(dataset_full_path, 'extra/thumbnail.jpg')
+            if exists(thumbnail_image_full_path):
+                 md['thumbnail'] = thumbnail_image_full_path
+            ###################################################################################
 
             manifest_files = find_pipeline_manifests(cwl_workflows)
             if ds_dir is not None and not ds_dir == '':

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -938,7 +938,7 @@ def make_send_status_msg_function(
             dataset_full_path = dataset_lz_path_fun(**kwargs)
             thumbnail_image_full_path = os.path.join(dataset_full_path, 'extra/thumbnail.jpg')
             if exists(thumbnail_image_full_path):
-                 md['thumbnail'] = thumbnail_image_full_path
+                 md['thumbnail_image'] = thumbnail_image_full_path
             ###################################################################################
 
             manifest_files = find_pipeline_manifests(cwl_workflows)

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -935,10 +935,10 @@ def make_send_status_msg_function(
                 
             ###################################################################################
             # Added by Zhou 6/16/2021 for registering thumbnail image
-            dataset_full_path = dataset_lz_path_fun(**kwargs)
-            thumbnail_image_full_path = join(dataset_full_path, 'extra/thumbnail.jpg')
-            if exists(thumbnail_image_full_path):
-                 md['thumbnail_image'] = thumbnail_image_full_path
+            dataset_dir_abs_path = dataset_lz_path_fun(**kwargs)
+            thumbnail_image_abs_path = join(dataset_dir_abs_path, 'extra/thumbnail.jpg')
+            if exists(thumbnail_image_abs_path):
+                 md['thumbnail_image_abs_path'] = thumbnail_image_abs_path
             ###################################################################################
 
             manifest_files = find_pipeline_manifests(cwl_workflows)


### PR DESCRIPTION
This PR addresses issue #328  with the following workflow:

- ingest-pipeline looks for the `extra/thumbnail.jpg` for a given dataset, and send back the absolute file path if found
- ingest-pipeline makes a PUT call to ingest-api's `/datasets/status` endpoint with the metadata
- ingest-api looks for the `thumbnail_file_abs_path` field and handles the dataset update along with all other updated records via entity-api.

@jswelling I've deployed all the related changes from entity-api/gateway/ingest-api on STAGE and tested the subsequent handling without using Airflow. I'm not sure if the changes I made in this PR would work, so can you please review and if all good, can you merge and deploy to STAGE so we can try it out?