### PR TITLE
Welling/validate uploads

### DIFF
--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -72,28 +72,10 @@ with DAG('validate_upload',
         if False:  # not ds_rslt['status'] in ['Processing']:
             raise AirflowException(f'Dataset {uuid} is not Processing')
 
-        dt = ds_rslt['data_types']
-        if isinstance(dt, str) and dt.startswith('[') and dt.endswith(']'):
-            dt = ast.literal_eval(dt)
-        print(f'parsed dt: {dt}')
-        if isinstance(dt, list):
-            if dt:
-                if len(dt) == 1:
-                    filtered_data_types = [dt[0]]
-                else:
-                    filtered_data_types = [tuple(dt)]
-            else:
-                raise AirflowException(f'Dataset data_types for {uuid}'
-                                       ' is empty')
-        else:
-            filtered_data_types = [dt]
-
         lz_path = ds_rslt['local_directory_full_path']
         uuid = ds_rslt['uuid']  # 'uuid' may  actually be a DOI
         print(f'Finished uuid {uuid}')
-        print(f'filtered data types: {filtered_data_types}')
         print(f'lz path: {lz_path}')
-        kwargs['ti'].xcom_push(key='assay_type', value=filtered_data_types)
         kwargs['ti'].xcom_push(key='lz_path', value=lz_path)
         kwargs['ti'].xcom_push(key='uuid', value=uuid)
 

--- a/src/ingest-pipeline/airflow/dags/validation_test.py
+++ b/src/ingest-pipeline/airflow/dags/validation_test.py
@@ -74,28 +74,10 @@ with DAG('validation_test',
         if not ds_rslt['status'] in ['New', 'Invalid']:
             raise AirflowException(f'Dataset {uuid} is not New or Invalid')
 
-        dt = ds_rslt['data_types']
-        if isinstance(dt, str) and dt.startswith('[') and dt.endswith(']'):
-            dt = ast.literal_eval(dt)
-        print(f'parsed dt: {dt}')
-        if isinstance(dt, list):
-            if dt:
-                if len(dt) == 1:
-                    filtered_data_types = [dt[0]]
-                else:
-                    filtered_data_types = [tuple(dt)]
-            else:
-                raise AirflowException(f'Dataset data_types for {uuid}'
-                                       ' is empty')
-        else:
-            filtered_data_types = [dt]
-
         lz_path = ds_rslt['local_directory_full_path']
         uuid = ds_rslt['uuid']  # 'uuid' may  actually be a DOI
         print(f'Finished uuid {uuid}')
-        print(f'filtered data types: {filtered_data_types}')
         print(f'lz path: {lz_path}')
-        kwargs['ti'].xcom_push(key='assay_type', value=filtered_data_types)
         kwargs['ti'].xcom_push(key='lz_path', value=lz_path)
         kwargs['ti'].xcom_push(key='uuid', value=uuid)
 


### PR DESCRIPTION
This PR updates the validation_test.py and validate_upload.py DAGs and a routine in utils.py on which they depend.  The goal is to support validating Uploads in addition to Datasets.  The changes are:
* modify utils.pythonop_get_dataset_state so that it can handle an Upload uuid in addition to a Dataset uuid
* remove some dead code from utils which had been inserted to support a transition period while other endpoints were updated
* modify validate_upload and validation_test to use the new version of pythonop_get_dataset_state .  This involved removing some logic dealing with dataset assay types, which wasn't needed anyway.