### PR TITLE
Welling/utils api no conn

### DIFF
--- a/src/ingest-pipeline/airflow/dags/launch_checksums.py
+++ b/src/ingest-pipeline/airflow/dags/launch_checksums.py
@@ -80,9 +80,10 @@ with DAG('launch_checksums',
         filtered_data_type = None
         print(f'Starting uuid {uuid}')
         my_callable = lambda **kwargs: uuid
-        rslt=utils.pythonop_get_dataset_state(dataset_uuid_callable=my_callable,
-                                              http_conn_id='ingest_api_connection',
-                                              **kwargs)
+        rslt=utils.pythonop_get_dataset_state(
+            dataset_uuid_callable=my_callable,
+            **kwargs
+        )
         if not rslt:
             raise AirflowException(f'Invalid uuid/doi: {uuid}')
         print('rslt:')

--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -64,9 +64,10 @@ with DAG('launch_multi_analysis',
         """
         print(f'Starting uuid {uuid}')
         my_callable = lambda **kwargs: uuid
-        ds_rslt=utils.pythonop_get_dataset_state(dataset_uuid_callable=my_callable,
-                                                 http_conn_id='ingest_api_connection',
-                                                 **kwargs)
+        ds_rslt=utils.pythonop_get_dataset_state(
+            dataset_uuid_callable=my_callable,
+            **kwargs
+        )
         if not ds_rslt:
             raise AirflowException(f'Invalid uuid/doi for group: {uuid}')
         print('ds_rslt:')

--- a/src/ingest-pipeline/airflow/dags/test_aws_batch.py
+++ b/src/ingest-pipeline/airflow/dags/test_aws_batch.py
@@ -91,7 +91,6 @@ with DAG('test_aws_batch',
     #         print(f'Starting uuid {uuid}')
     #         my_callable = lambda **kwargs: uuid
     #         rslt=utils.pythonop_get_dataset_state(dataset_uuid_callable=my_callable,
-    #                                               http_conn_id='ingest_api_connection',
     #                                               **kwargs)
     #         if not rslt:
     #             raise AirflowException(f'Invalid uuid/doi for group: {uuid}')

--- a/src/ingest-pipeline/airflow/dags/trigger_downstream_processing.py
+++ b/src/ingest-pipeline/airflow/dags/trigger_downstream_processing.py
@@ -55,7 +55,6 @@ with DAG('trigger_downstream_processing',
 
         ds_rslt = utils.pythonop_get_dataset_state(
             dataset_uuid_callable=my_callable,
-            http_conn_id='ingest_api_connection',
             **kwargs
         )
         if not ds_rslt:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -784,7 +784,7 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
         'content-type' : 'application/json',
         'X-Hubmap-Application' : 'ingest-pipeline',
         }
-    http_hook = HttpHook(method, http_conn_id='ingest-api-connection')
+    http_hook = HttpHook(method, http_conn_id='ingest_api_connection')
 
     endpoint = f'entities/{uuid}'
 
@@ -846,7 +846,7 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
     }
 
     if ds_rslt['entity_type'] == 'Dataset':
-        http_hook = HttpHook('GET', http_conn_id='entity-api-connection')
+        http_hook = HttpHook('GET', http_conn_id='entity_api_connection')
         endpoint = f"datasets/{ds_rslt['uuid']}/organs"
         try:
             response = http_hook.run(endpoint,
@@ -863,7 +863,7 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
             else:
                 print('benign error')
                 return {}
-        rslt['organs'] = [entry['organ] for entry in organs_query_rslt]
+        rslt['organs'] = [entry['organ'] for entry in organs_query_rslt]
         
     return rslt
 

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -856,6 +856,7 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
             organs_query_rslt = response.json()
             print('organs_query_rslt:')
             pprint(organs_query_rslt)
+            rslt['organs'] = [entry['organ'] for entry in organs_query_rslt]
         except HTTPError as e:
             print(f'ERROR: {e}')
             if e.response.status_code == codes.unauthorized:
@@ -863,7 +864,6 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
             else:
                 print('benign error')
                 return {}
-        rslt['organs'] = [entry['organ'] for entry in organs_query_rslt]
         
     return rslt
 

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -772,13 +772,11 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
     
     Accepts the following via the caller's op_kwargs:
     'dataset_uuid_callable' : called with **kwargs; returns the
-                              uuid of the dataset to be modified
-    'http_conn_id' : the http connection to be used
+                              uuid of the Dataset or Upload to be examined
     """
-    for arg in ['dataset_uuid_callable', 'http_conn_id']:
+    for arg in ['dataset_uuid_callable']:
         assert arg in kwargs, "missing required argument {}".format(arg)
     uuid = kwargs['dataset_uuid_callable'](**kwargs)
-    http_conn_id = kwargs['http_conn_id']
     method = 'GET'
     auth_tok = get_auth_tok(**kwargs)
     headers = {
@@ -786,7 +784,7 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
         'content-type' : 'application/json',
         'X-Hubmap-Application' : 'ingest-pipeline',
         }
-    http_hook = HttpHook(method, http_conn_id=http_conn_id)
+    http_hook = HttpHook(method, http_conn_id='ingest-api-connection')
 
     endpoint = f'entities/{uuid}'
 
@@ -834,7 +832,8 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
         else:
             print('benign error')
             return {}
-    assert 'path' in path_query_rslt, f"Dataset path for {uuid} produced no path"
+    assert 'path' in path_query_rslt, (f"Dataset path for {uuid} produced"
+                                       " no path")
     full_path = path_query_rslt['path']
 
     rslt = {
@@ -845,6 +844,27 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
         'local_directory_full_path': full_path,
         'metadata': metadata,
     }
+
+    if ds_rslt['entity_type'] == 'Dataset':
+        http_hook = HttpHook('GET', http_conn_id='entity-api-connection')
+        endpoint = f"datasets/{ds_rslt['uuid']}/organs"
+        try:
+            response = http_hook.run(endpoint,
+                                     headers=headers,
+                                     extra_options={'check_response': False})
+            response.raise_for_status()
+            organs_query_rslt = response.json()
+            print('organs_query_rslt:')
+            pprint(organs_query_rslt)
+        except HTTPError as e:
+            print(f'ERROR: {e}')
+            if e.response.status_code == codes.unauthorized:
+                raise RuntimeError('entity database authorization was rejected?')
+            else:
+                print('benign error')
+                return {}
+        rslt['organs'] = [entry['organ] for entry in organs_query_rslt]
+        
     return rslt
 
 

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -57,7 +57,6 @@ with DAG('validate_upload',
 
         ds_rslt = pythonop_get_dataset_state(
             dataset_uuid_callable=my_callable,
-            http_conn_id='ingest_api_connection',
             **kwargs
         )
         if not ds_rslt:

--- a/src/ingest-pipeline/airflow/dags/validation_test.py
+++ b/src/ingest-pipeline/airflow/dags/validation_test.py
@@ -59,7 +59,6 @@ with DAG('validation_test',
 
         ds_rslt = utils.pythonop_get_dataset_state(
             dataset_uuid_callable=my_callable,
-            http_conn_id='ingest_api_connection',
             **kwargs
         )
         if not ds_rslt:


### PR DESCRIPTION
Purpose:
* Modify utils.pythonop_get_dataset_state() to provide an additional entry in its output dict if the given uuid is that of a Dataset, containing a list of organ codes like "organs":['LI']
* Remove http_conn_id from the parameters of utils.pythonop_get_dataset_state(), because the organ info must be grabbed from a different connection.
* remove the http_conn_id keyword from the various DAGs that call that routine