### PR TITLE
Welling/use ignore deprecation

### DIFF
--- a/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
+++ b/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
@@ -88,7 +88,8 @@ with DAG('scan_and_begin_processing',
             upload_ignore_globs='*',
             plugin_directory=plugin_path,
             #offline=True,  # noqa E265
-            add_notes=False
+            add_notes=False,
+            ignore_deprecation=True
         )
         # Scan reports an error result
         errors = upload.get_errors(plugin_kwargs=kwargs)


### PR DESCRIPTION
This PR:
* applies the ignore_deprecation flag to ingest validation performed in scan_and_begin_processing
* turns off the separate application of validation performed by the generic_metadatatsv metadata file format reader
* bumps the ingest-validation-tools submodule to a commit which includes the flag