### PR TITLE
SPRM v1.0.8.2 for CellDIVE

### DIFF
--- a/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
@@ -140,6 +140,7 @@ with DAG(
             *get_cwltool_base_cmd(tmpdir),
             cwl_workflows["sprm"],
             "--enable_manhole",
+            "--options_preset=celldive",
             "--image_dir",
             data_dir / "pipeline_output/expr",
             "--mask_dir",


### PR DESCRIPTION
Well, technically for all data types processed by SPRM, but behavior for other assays is unchanged. This version of SPRM:
* Adds a mechanism to specify different options files ("presets") that are included with the software package and baked into the Docker image
* Adjusts two different tSNE parameters in the new `options-celldive.txt`

The update to the CellDIVE DAG sets the new `--options_preset` workflow option to `celldive`.