### PR TITLE
Welling/scan bail on failed validate

### DIFF
--- a/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
+++ b/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
@@ -144,9 +144,9 @@ with HMDAG('scan_and_begin_processing',
         else:
             kwargs['ti'].xcom_push(key='collectiontype', value=None)
 
-    t_maybe_continue - BranchPythonOperator(
+    t_maybe_continue = BranchPythonOperator(
         task_id='maybe_continue',
-        python_callcable=pythonop_maybe_keep,
+        python_callable=pythonop_maybe_keep,
         provide_context=True,
         op_kwargs={
             'next_op': 'run_md_extract',
@@ -247,4 +247,4 @@ with HMDAG('scan_and_begin_processing',
      t_maybe_continue >>
      t_run_md_extract >> t_md_consistency_tests >>
      t_send_status >> t_maybe_spawn >> t_cleanup_tmpdir)
-
+    t_maybe_continue >> t_send_status

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1111,9 +1111,10 @@ def make_send_status_msg_function(
     """
     def send_status_msg(**kwargs) -> bool:
         retcodes = [
-            int(kwargs['ti'].xcom_pull(task_ids=op))
+            kwargs['ti'].xcom_pull(task_ids=op)
             for op in retcode_ops
         ]
+        retcodes = [int(rc or '0') for rc in retcodes]
         print('retcodes: ', {k: v for k, v in zip(retcode_ops, retcodes)})
         success = all(rc == 0 for rc in retcodes)
         if dataset_uuid_fun is None:


### PR DESCRIPTION
This PR modifies the Airflow DAG used to ingest primary datasets, such that a cleaner exit occurs if the dataset fails validation.  The previous state of the DAG caused some extraneous messages to be included in the diagnostics uploaded as a result of the failure.  This change prevents those extraneous messages and thus prevents their inclusion in the diagnostic presented to the data provider when a dataset is found to be invalid.