### PR TITLE
Add fastq-utils to requirements.txt

### DIFF
--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -16,6 +16,7 @@ rdflib==4.2.2
 rdflib-jsonld==0.4.0
 Flask-OAuthlib==0.9.6
 git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
+git+https://github.com/hubmapconsortium/fastq-utils@v0.2.4#egg=hubmap-fastq-utils
 # We need the dependencies of ingest-validation tools, but relative paths don't work
 # -r ${CWD}/submodules/ingest-validation-tools/requirements.txt
 #jsonschema==3.2.0


### PR DESCRIPTION
This adds fastq-utils to requirements.txt via github.  Since this is now a requirement of ingest-validation-tests, one of our submodules, it must be a requirement here as well.