### PR TITLE
fastq_utils requires dataclasses, not present in python 3.6

### DIFF
--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -15,6 +15,7 @@ PyYAML>=5.3.1
 rdflib==4.2.2
 rdflib-jsonld==0.4.0
 Flask-OAuthlib==0.9.6
+dataclasses
 git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
 git+https://github.com/hubmapconsortium/fastq-utils@v0.2.4#egg=hubmap-fastq-utils
 # We need the dependencies of ingest-validation tools, but relative paths don't work


### PR DESCRIPTION
The python version on production HIVE is currently stuck at 3.6 for OS reasons.  dataclasses becomes a standard module at 3.7, and it is needed by fastq_utils .  This PR adds dataclasses to requirements.txt .