### PR TITLE
Welling/utils hotfix

### DIFF
--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -38,6 +38,7 @@ from hubmap_commons.type_client import TypeClient
 import cwltool  # used to find its path
 
 
+airflow_conf.read(join(environ['AIRFLOW_HOME'], 'instance', 'app.cfg'))
 try:
     sys.path.append(airflow_conf.as_dict()['connections']['SRC_PATH']
                     .strip("'").strip('"'))


### PR DESCRIPTION
This PR addresses a problem whereby the extra config info from app.cfg is not always included in the Airflow configuration when it is needed.  