### PR TITLE
Welling/replace metadata assay type improvements

### DIFF
--- a/src/ingest-pipeline/misc/tools/replace_metadata_assay_type.sh
+++ b/src/ingest-pipeline/misc/tools/replace_metadata_assay_type.sh
@@ -2,8 +2,10 @@
 
 set -e  # really exit on error
 
-old_assay_name='LC-MS (metabolomics)'
-new_assay_name='LC-MS'
+#old_assay_name='LC-MS (metabolomics)'
+#new_assay_name='LC-MS'
+old_assay_name='LC-MS/MS (label-free proteomics)'
+new_assay_name='LC-MS Bottom-Up'
 uuid=$1
 echo $uuid
 echo `basename "$PWD"`
@@ -22,7 +24,9 @@ extras_prot=`stat -c '%a' extras`
 chmod u+w extras
 prot=`stat -c '%a' $fname`
 mv $fname extras/${fname}.orig
-sed "s/${old_assay_name}/${new_assay_name}/" < extras/${fname}.orig > $fname
+ESCAPED_REPLACE=$(printf '%s\n' "$new_assay_name" | sed -e 's/[\/&]/\\&/g')
+ESCAPED_KEYWORD=$(printf '%s\n' "$old_assay_name" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed "s/${ESCAPED_KEYWORD}/${ESCAPED_REPLACE}/" < extras/${fname}.orig > $fname
 chmod $prot $fname
 chmod $extras_prot extras
 chmod $dir_prot .

--- a/src/ingest-pipeline/misc/tools/replace_metadata_assay_type.sh
+++ b/src/ingest-pipeline/misc/tools/replace_metadata_assay_type.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -ex
 
-old_assay_name='MALDI-IMS-neg'
-new_assay_name='MALDI-IMS'
+set -e  # really exit on error
+
+old_assay_name='LC-MS (metabolomics)'
+new_assay_name='LC-MS'
 uuid=$1
 echo $uuid
 echo `basename "$PWD"`
@@ -13,6 +15,19 @@ fi
 fname=`ls *metadata.tsv | head -1`
 echo $fname
 
+dir_prot=`stat -c '%a' .`
+chmod u+w .
 mkdir -p extras
+extras_prot=`stat -c '%a' extras`
+chmod u+w extras
+prot=`stat -c '%a' $fname`
 mv $fname extras/${fname}.orig
 sed "s/${old_assay_name}/${new_assay_name}/" < extras/${fname}.orig > $fname
+chmod $prot $fname
+chmod $extras_prot extras
+chmod $dir_prot .
+cmp --silent $fname extras/${fname}.orig
+if [ ! $? ] ; then
+    echo "The edit to metadata made no change!"
+    exit -1
+fi

--- a/src/ingest-pipeline/misc/tools/replace_metadata_assay_type.sh
+++ b/src/ingest-pipeline/misc/tools/replace_metadata_assay_type.sh
@@ -2,10 +2,9 @@
 
 set -e  # really exit on error
 
-#old_assay_name='LC-MS (metabolomics)'
-#new_assay_name='LC-MS'
 old_assay_name='LC-MS/MS (label-free proteomics)'
 new_assay_name='LC-MS Bottom-Up'
+
 uuid=$1
 echo $uuid
 echo `basename "$PWD"`
@@ -17,15 +16,15 @@ fi
 fname=`ls *metadata.tsv | head -1`
 echo $fname
 
-dir_prot=`stat -c '%a' .`
+dir_prot="$(stat -c '%a' .)"
 chmod u+w .
 mkdir -p extras
-extras_prot=`stat -c '%a' extras`
+extras_prot="$(stat -c '%a' extras)"
 chmod u+w extras
-prot=`stat -c '%a' $fname`
+prot="$(stat -c '%a' $fname)"
 mv $fname extras/${fname}.orig
 ESCAPED_REPLACE=$(printf '%s\n' "$new_assay_name" | sed -e 's/[\/&]/\\&/g')
-ESCAPED_KEYWORD=$(printf '%s\n' "$old_assay_name" | sed -e 's/[]\/$*.^[]/\\&/g');
+ESCAPED_KEYWORD=$(printf '%s\n' "$old_assay_name" | sed -e 's/[]\/$*.^[]/\\&/g')
 sed "s/${ESCAPED_KEYWORD}/${ESCAPED_REPLACE}/" < extras/${fname}.orig > $fname
 chmod $prot $fname
 chmod $extras_prot extras


### PR DESCRIPTION
This PR involves improvements to a utility script used to substitute replacement assay type strings into metadata.tsv files.  The changes relate to preserving permissions when files are moved or duplicated, and coping with assay type strings containing spaces.