### PR TITLE
Welling/cleanup scratch resource

### DIFF
--- a/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
@@ -29,7 +29,8 @@ from utils import (
     make_send_status_msg_function,
     get_tmp_dir_path,
     HMDAG,
-    get_queue_resource
+    get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 THREADS = 6  # to be used by the CWL worker
@@ -53,7 +54,10 @@ with HMDAG(
         schedule_interval=None,
         is_paused_upon_creation=False,
         default_args=default_args,
-        user_defined_macros={'tmp_dir_path': get_tmp_dir_path},
+        user_defined_macros={
+            'tmp_dir_path': get_tmp_dir_path,
+            'preserve_scratch': get_preserve_scratch_resource('bulk_atacseq'),
+        },
 ) as dag:
     pipeline_name = 'bulk-atac-seq'
     cwl_workflows = get_absolute_workflows(

--- a/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
@@ -21,6 +21,7 @@ from utils import (
     get_tmp_dir_path,
     HMDAG,
     get_queue_resource,
+    get_preserve_scratch_resource,
 )
 from hubmap_operators.common_operators import (
     CleanupTmpDirOperator,
@@ -52,7 +53,10 @@ with HMDAG(
         schedule_interval=None,
         is_paused_upon_creation=False,
         default_args=default_args,
-        user_defined_macros={"tmp_dir_path": get_tmp_dir_path},
+        user_defined_macros={
+            "tmp_dir_path": get_tmp_dir_path,
+             'preserve_scratch': get_preserve_scratch_resource('celldive_deepcell'),
+        },
 ) as dag:
 
     pipeline_name = "celldive-pipeline"

--- a/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
@@ -55,7 +55,7 @@ with HMDAG(
         default_args=default_args,
         user_defined_macros={
             "tmp_dir_path": get_tmp_dir_path,
-             'preserve_scratch': get_preserve_scratch_resource('celldive_deepcell'),
+            'preserve_scratch': get_preserve_scratch_resource('celldive_deepcell'),
         },
 ) as dag:
 

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -29,7 +29,8 @@ from utils import (
     make_send_status_msg_function,
     get_tmp_dir_path,
     HMDAG,
-    get_queue_resource
+    get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 
@@ -52,7 +53,10 @@ with HMDAG("codex_cytokit",
            schedule_interval=None,
            is_paused_upon_creation=False,
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path' : get_tmp_dir_path}
+           user_defined_macros={
+               'tmp_dir_path' : get_tmp_dir_path,
+               'preserve_scratch': get_preserve_scratch_resource('codex_cytokit'),
+           }
 ) as dag:
 
     pipeline_name = 'codex-pipeline'

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -56,7 +56,7 @@ with HMDAG("codex_cytokit",
            user_defined_macros={
                'tmp_dir_path' : get_tmp_dir_path,
                'preserve_scratch': get_preserve_scratch_resource('codex_cytokit'),
-           }
+           },
 ) as dag:
 
     pipeline_name = 'codex-pipeline'

--- a/src/ingest-pipeline/airflow/dags/devtest_step2.py
+++ b/src/ingest-pipeline/airflow/dags/devtest_step2.py
@@ -52,7 +52,7 @@ with HMDAG(
         default_args=default_args,
         user_defined_macros={
             'tmp_dir_path': get_tmp_dir_path,
-             'preserve_scratch': get_preserve_scratch_resource('devtest_step2'),
+            'preserve_scratch': get_preserve_scratch_resource('devtest_step2'),
         },
 ) as dag:
     pipeline_name = 'devtest-step2-pipeline'

--- a/src/ingest-pipeline/airflow/dags/devtest_step2.py
+++ b/src/ingest-pipeline/airflow/dags/devtest_step2.py
@@ -27,7 +27,8 @@ from utils import (
     make_send_status_msg_function,
     get_tmp_dir_path,
     HMDAG,
-    get_queue_resource
+    get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 default_args = {
@@ -49,7 +50,10 @@ with HMDAG(
         schedule_interval=None,
         is_paused_upon_creation=False,
         default_args=default_args,
-        user_defined_macros={'tmp_dir_path': get_tmp_dir_path},
+        user_defined_macros={
+            'tmp_dir_path': get_tmp_dir_path,
+             'preserve_scratch': get_preserve_scratch_resource('devtest_step2'),
+        },
 ) as dag:
     pipeline_name = 'devtest-step2-pipeline'
 

--- a/src/ingest-pipeline/airflow/dags/generate_bdbag.py
+++ b/src/ingest-pipeline/airflow/dags/generate_bdbag.py
@@ -32,6 +32,8 @@ from utils import (
     get_auth_tok,
     find_matching_endpoint,
     get_type_client,
+    get_queue_resource,
+    get_preserve_scratch_resource,
     )
 
 sys.path.append(airflow_conf.as_dict()['connections']['SRC_PATH']
@@ -93,15 +95,18 @@ default_args = {
     'retries': 1,
     'retry_delay': datetime.timedelta(minutes=1),
     'xcom_push': True,
-    'queue': utils.map_queue_name('general')
+    'queue': get_queue_resource('generate_bdbag'),
 }
 
 with HMDAG('generate_bdbag',
            schedule_interval=None,
            is_paused_upon_creation=False,
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path': get_tmp_dir_path}
-           ) as dag:
+           user_defined_macros={
+               'tmp_dir_path': get_tmp_dir_path,
+               'preserve_scratch': get_preserve_scratch_resource('generate_bdbag'),
+           }
+       ) as dag:
 
 
     def get_dataset_full_path(uuid, auth_token):

--- a/src/ingest-pipeline/airflow/dags/generate_bdbag.py
+++ b/src/ingest-pipeline/airflow/dags/generate_bdbag.py
@@ -105,7 +105,7 @@ with HMDAG('generate_bdbag',
            user_defined_macros={
                'tmp_dir_path': get_tmp_dir_path,
                'preserve_scratch': get_preserve_scratch_resource('generate_bdbag'),
-           }
+           },
        ) as dag:
 
 
@@ -419,7 +419,7 @@ with HMDAG('generate_bdbag',
      >> t_create_tmpdir
      >> t_generate_bdbag
      >> t_cleanup_tmpdir
-     )
+    )
 
 
 

--- a/src/ingest-pipeline/airflow/dags/generate_bdbag.py
+++ b/src/ingest-pipeline/airflow/dags/generate_bdbag.py
@@ -105,8 +105,7 @@ with HMDAG('generate_bdbag',
            user_defined_macros={
                'tmp_dir_path': get_tmp_dir_path,
                'preserve_scratch': get_preserve_scratch_resource('generate_bdbag'),
-           },
-       ) as dag:
+           }) as dag:
 
 
     def get_dataset_full_path(uuid, auth_token):

--- a/src/ingest-pipeline/airflow/dags/generate_usage_report.py
+++ b/src/ingest-pipeline/airflow/dags/generate_usage_report.py
@@ -25,7 +25,9 @@ from utils import (
     HMDAG,
     get_tmp_dir_path,
     get_auth_tok,
-    find_matching_endpoint
+    find_matching_endpoint,
+    get_queue_resource,
+    get_preserve_scratch_resource,
     )
 
 default_args = {
@@ -38,15 +40,18 @@ default_args = {
     'retries': 1,
     'retry_delay': datetime.timedelta(minutes=1),
     'xcom_push': True,
-    'queue': utils.map_queue_name('general')
+    'queue': get_queue_resource('generate_usage_report')
 }
 
 with HMDAG('generate_usage_report',
            schedule_interval='@weekly',
            is_paused_upon_creation=False,
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path': get_tmp_dir_path}
-           ) as dag:
+           user_defined_macros={
+               'tmp_dir_path': get_tmp_dir_path,
+               'preserve_scratch': get_preserve_scratch_resource('generate_usage_report'),
+           }
+       ) as dag:
 
     def build_report(**kwargs):
         entity_token = get_auth_tok(**kwargs)

--- a/src/ingest-pipeline/airflow/dags/generate_usage_report.py
+++ b/src/ingest-pipeline/airflow/dags/generate_usage_report.py
@@ -50,7 +50,7 @@ with HMDAG('generate_usage_report',
            user_defined_macros={
                'tmp_dir_path': get_tmp_dir_path,
                'preserve_scratch': get_preserve_scratch_resource('generate_usage_report'),
-           }
+           },
        ) as dag:
 
     def build_report(**kwargs):
@@ -257,5 +257,5 @@ with HMDAG('generate_usage_report',
      >> t_create_tmpdir
      >> t_build_report
      >> t_cleanup_tmpdir
-     )
+    )
 

--- a/src/ingest-pipeline/airflow/dags/launch_checksums.py
+++ b/src/ingest-pipeline/airflow/dags/launch_checksums.py
@@ -25,6 +25,7 @@ from utils import (
     get_threads_resource,
     get_auth_tok,
     get_tmp_dir_path,
+    get_preserve_scratch_resource,
 )
 
 
@@ -54,7 +55,8 @@ with HMDAG('launch_checksums',
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'src_path' : (airflow_conf.as_dict()['connections']['SRC_PATH']
                              .strip('"').strip("'")),
-               'THREADS' : get_threads_resource('launch_checksums')
+               'THREADS' : get_threads_resource('launch_checksums'),
+               'preserve_scratch' : get_preserve_scratch_resource('launch_checksums')
            }
            ) as dag:
 

--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -57,7 +57,7 @@ with HMDAG('launch_multi_analysis',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('launch_multi_analysis')
-           }
+           },
        ) as dag:
 
 

--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -57,8 +57,7 @@ with HMDAG('launch_multi_analysis',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('launch_multi_analysis')
-           },
-       ) as dag:
+           }) as dag:
 
 
     def check_one_uuid(uuid, **kwargs):

--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -23,7 +23,8 @@ import utils
 from utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,
     HMDAG,
-    get_queue_resource
+    get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 
@@ -50,11 +51,14 @@ default_args = {
 
 
 with HMDAG('launch_multi_analysis', 
-         schedule_interval=None, 
-         is_paused_upon_creation=False, 
-         default_args=default_args,
-         user_defined_macros={'tmp_dir_path' : utils.get_tmp_dir_path}
-         ) as dag:
+           schedule_interval=None, 
+           is_paused_upon_creation=False, 
+           default_args=default_args,
+           user_defined_macros={
+               'tmp_dir_path' : utils.get_tmp_dir_path,
+               'preserve_scratch' : get_preserve_scratch_resource('launch_multi_analysis')
+           }
+       ) as dag:
 
 
     def check_one_uuid(uuid, **kwargs):

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -60,8 +60,7 @@ with HMDAG('ometiff_pyramid',
            user_defined_macros={
                'tmp_dir_path' : get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('ometiff_pyramid'),
-           }
-       ) as dag:
+           }) as dag:
 
     # does the name need to match the filename?
     pipeline_name = 'ometiff_pyramid'

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -32,6 +32,7 @@ from utils import (
     get_tmp_dir_path,
     HMDAG,
     get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 # after running this DAG you should have on disk
@@ -56,7 +57,10 @@ with HMDAG('ometiff_pyramid',
            schedule_interval=None,
            is_paused_upon_creation=False,
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path' : get_tmp_dir_path}
+           user_defined_macros={
+               'tmp_dir_path' : get_tmp_dir_path,
+               'preserve_scratch' : get_preserve_scratch_resource('ometiff_pyramid'),
+           }
        ) as dag:
 
     # does the name need to match the filename?

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -50,7 +50,7 @@ default_args = {
     'retry_delay': timedelta(minutes=1),
     'xcom_push': True,
     'queue': get_queue_resource('ometiff_pyramid'),
-    'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error)
+    'on_failure_callback': utils.create_dataset_state_error_callback(get_uuid_for_error),
 }
 
 with HMDAG('ometiff_pyramid',

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -63,7 +63,7 @@ with HMDAG('ometiff_pyramid_ims',
            user_defined_macros={
                'tmp_dir_path' : get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('ometiff_pyramid_ims'),
-           }
+           },
        ) as dag:
 
     # does the name need to match the filename?

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -63,8 +63,7 @@ with HMDAG('ometiff_pyramid_ims',
            user_defined_macros={
                'tmp_dir_path' : get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('ometiff_pyramid_ims'),
-           },
-       ) as dag:
+           }) as dag:
 
     # does the name need to match the filename?
     pipeline_name = 'ometiff_pyramid_ims'

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -32,6 +32,7 @@ from utils import (
     get_tmp_dir_path,
     HMDAG,
     get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 # Passed directly to the pipeline
@@ -59,7 +60,10 @@ with HMDAG('ometiff_pyramid_ims',
            schedule_interval=None,
            is_paused_upon_creation=False,
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path' : get_tmp_dir_path}
+           user_defined_macros={
+               'tmp_dir_path' : get_tmp_dir_path,
+               'preserve_scratch' : get_preserve_scratch_resource('ometiff_pyramid_ims'),
+           }
        ) as dag:
 
     # does the name need to match the filename?

--- a/src/ingest-pipeline/airflow/dags/reorganize_upload.py
+++ b/src/ingest-pipeline/airflow/dags/reorganize_upload.py
@@ -26,6 +26,7 @@ from utils import (
     find_matching_endpoint,
     HMDAG,
     get_queue_resource,
+    get_preserve_scratch_resource,
     )
 
 sys.path.append(airflow_conf.as_dict()['connections']['SRC_PATH']
@@ -67,7 +68,8 @@ with HMDAG('reorganize_upload',
            user_defined_macros={
                'tmp_dir_path' : get_tmp_dir_path,
                'frozen_df_path' : _get_frozen_df_path,
-               'frozen_df_wildcard': _get_frozen_df_wildcard
+               'frozen_df_wildcard': _get_frozen_df_wildcard,
+               'preserve_scratch' : get_preserve_scratch_resource('reorganize_upload'),
            },
            default_args=default_args,
        ) as dag:

--- a/src/ingest-pipeline/airflow/dags/reorganize_upload.py
+++ b/src/ingest-pipeline/airflow/dags/reorganize_upload.py
@@ -232,7 +232,8 @@ with HMDAG('reorganize_upload',
      >> t_maybe_keep_2
      >> t_join
      >> t_preserve_info
-     >> t_cleanup_tmpdir)
+     >> t_cleanup_tmpdir
+    )
 
     t_maybe_keep_1 >> t_set_dataset_error
     t_maybe_keep_2 >> t_set_dataset_error

--- a/src/ingest-pipeline/airflow/dags/reorganize_upload.py
+++ b/src/ingest-pipeline/airflow/dags/reorganize_upload.py
@@ -71,8 +71,7 @@ with HMDAG('reorganize_upload',
                'frozen_df_wildcard': _get_frozen_df_wildcard,
                'preserve_scratch' : get_preserve_scratch_resource('reorganize_upload'),
            },
-           default_args=default_args,
-       ) as dag:
+           default_args=default_args) as dag:
 
     def find_uuid(**kwargs):
         uuid = kwargs['dag_run'].conf['uuid']

--- a/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
+++ b/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
@@ -20,6 +20,7 @@ from utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 UUIDS_TO_RESET = [
@@ -68,7 +69,10 @@ with HMDAG('reset_submission_to_new',
            schedule_interval=None, 
            is_paused_upon_creation=False, 
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path' : utils.get_tmp_dir_path}
+           user_defined_macros={
+               'tmp_dir_path' : utils.get_tmp_dir_path,
+               'preserve_scratch' : get_preserve_scratch_resource('reset_submission_to_new'),
+           }
        ) as dag:
 
     prev = dag

--- a/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
+++ b/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
@@ -72,8 +72,7 @@ with HMDAG('reset_submission_to_new',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('reset_submission_to_new'),
-           },
-       ) as dag:
+           }) as dag:
 
     prev = dag
     

--- a/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
+++ b/src/ingest-pipeline/airflow/dags/reset_submission_to_new.py
@@ -72,7 +72,7 @@ with HMDAG('reset_submission_to_new',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('reset_submission_to_new'),
-           }
+           },
        ) as dag:
 
     prev = dag

--- a/src/ingest-pipeline/airflow/dags/resource_map.yml
+++ b/src/ingest-pipeline/airflow/dags/resource_map.yml
@@ -2,13 +2,22 @@
 # ids will provide the entries for that DAG and task, so safe defaults defined
 # by wildcards for last.
 resource_map:
+  - 'dag_re': 'test_workflow'
+    'preserve_scratch': true
+    'lanes': 1
+    'tasks':
+    - 'task_re': '.*'
+      'queue': 'general'
+      'threads': 1
   - 'dag_re': 'celldive_deepcell'
+    'preserve_scratch': true
     'lanes': 2
     'tasks':
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'salmon_rnaseq_.*'
+    'preserve_scratch': true
     'lanes': 2
     # 'lanes': 12
     'tasks':
@@ -16,18 +25,21 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'generate_bdbag'
+    'preserve_scratch': true
     'lanes': 1
     'tasks':
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'generate_usage_report'
+    'preserve_scratch': true
     'lanes': 1
     'tasks':
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'codex_cytokit'
+    'preserve_scratch': true
     'lanes': 2
     # 'lanes': 6
     'tasks':
@@ -38,6 +50,7 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'celldive_deepcell'
+    'preserve_scratch': true
     'lanes': 2
     'tasks':
     - 'task_re': '.*cwl_segmentation'
@@ -47,6 +60,7 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'ometiff_offset'
+    'preserve_scratch': true
     'lanes': 2
     # 'lanes': 6
     'tasks':
@@ -54,12 +68,14 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'launch_checksums'
+    'preserve_scratch': true
     'lanes': 2
     'tasks':
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'scan_and_begin_processing'
+    'preserve_scratch': true
     'lanes': 2
     'tasks':
     - 'task_re': 'run_validation'
@@ -69,6 +85,7 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'validate_upload'
+    'preserve_scratch': true
     'lanes': 2
     'tasks':
     - 'task_re': 'run_validation'
@@ -78,6 +95,7 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'validation_test'
+    'preserve_scratch': true
     'lanes': 2
     'tasks':
     - 'task_re': 'run_validation'
@@ -87,6 +105,7 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': 'sc_atac_seq_.*'
+    'preserve_scratch': true
     'lanes': 8
     # 'lanes': 11
     'tasks':
@@ -94,6 +113,7 @@ resource_map:
       'queue': 'general'
       'threads': 6
   - 'dag_re': '.*'
+    'preserve_scratch': true
     'lanes': 2
     'tasks':
       - 'task_re': '.*'

--- a/src/ingest-pipeline/airflow/dags/resource_map.yml
+++ b/src/ingest-pipeline/airflow/dags/resource_map.yml
@@ -3,7 +3,7 @@
 # by wildcards for last.
 resource_map:
   - 'dag_re': 'test_workflow'
-    'preserve_scratch': true
+    'preserve_scratch': false
     'lanes': 1
     'tasks':
     - 'task_re': '.*'

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
@@ -33,6 +33,7 @@ from utils import (
     HMDAG,
     get_queue_resource,
     get_threads_resource,
+    get_preserve_scratch_resource,
 )
 
 
@@ -56,7 +57,10 @@ def generate_salmon_rnaseq_dag(params: SequencingDagParameters) -> DAG:
         schedule_interval=None,
         is_paused_upon_creation=False,
         default_args=default_args,
-        user_defined_macros={"tmp_dir_path": get_tmp_dir_path},
+        user_defined_macros={
+            "tmp_dir_path": get_tmp_dir_path,
+            "preserve_scratch": get_preserve_scratch_resource(params.dag_id),
+        },
     ) as dag:
 
         cwl_workflows = get_absolute_workflows(

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
@@ -31,6 +31,7 @@ from utils import (
     HMDAG,
     get_queue_resource,
     get_threads_resource,
+    get_preserve_scratch_resource,
 )
 
 default_args = {
@@ -52,7 +53,10 @@ with HMDAG(
         schedule_interval=None,
         is_paused_upon_creation=False,
         default_args=default_args,
-        user_defined_macros={'tmp_dir_path': get_tmp_dir_path},
+        user_defined_macros={
+            'tmp_dir_path': get_tmp_dir_path,
+            'preserve_scratch': get_preserve_scratch_resource('salmon_rnaseq_bulk'),
+        },
 ) as dag:
     pipeline_name = 'salmon-rnaseq-bulk'
     cwl_workflows = get_absolute_workflows(

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
@@ -32,6 +32,7 @@ from utils import (
     HMDAG,
     get_queue_resource,
     get_threads_resource,
+    get_preserve_scratch_resource,
 )
 
 
@@ -55,7 +56,10 @@ def generate_atac_seq_dag(params: SequencingDagParameters) -> DAG:
         schedule_interval=None,
         is_paused_upon_creation=False,
         default_args=default_args,
-        user_defined_macros={"tmp_dir_path": get_tmp_dir_path},
+        user_defined_macros={
+            "tmp_dir_path": get_tmp_dir_path,
+            "preserve_scratch": get_preserve_scratch_resource(params.dag_id),
+        },
     ) as dag:
         cwl_workflows = get_absolute_workflows(
             Path("sc-atac-seq-pipeline", "sc_atac_seq_prep_process_analyze.cwl"),

--- a/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
+++ b/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
@@ -17,6 +17,11 @@ from airflow.operators.multi_dagrun import TriggerMultiDagRunOperator
 from airflow.hooks.http_hook import HttpHook
 
 from hubmap_operators.flex_multi_dag_run import FlexMultiDagRunOperator
+from hubmap_operators.common_operators import (
+    CreateTmpDirOperator,
+    CleanupTmpDirOperator,
+)
+
 import utils
 
 from utils import (
@@ -24,6 +29,7 @@ from utils import (
     make_send_status_msg_function,
     HMDAG,
     get_queue_resource,
+    get_preserve_scratch_resource,
     pythonop_maybe_keep,
     )
 
@@ -64,7 +70,10 @@ with HMDAG('scan_and_begin_processing',
            schedule_interval=None, 
            is_paused_upon_creation=False, 
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path' : utils.get_tmp_dir_path}         
+           user_defined_macros={
+               'tmp_dir_path' : utils.get_tmp_dir_path,
+               'preserve_scratch' : get_preserve_scratch_resource('scan_and_begin_processing')
+           }
        ) as dag:
 
     def read_metadata_file(**kwargs):
@@ -188,16 +197,8 @@ with HMDAG('scan_and_begin_processing',
         trigger_rule='all_done'
     )
 
-    t_create_tmpdir = BashOperator(
-        task_id='create_temp_dir',
-        bash_command='mkdir {{tmp_dir_path(run_id)}}'
-        )
-
-    t_cleanup_tmpdir = BashOperator(
-        task_id='cleanup_temp_dir',
-        bash_command='echo rm -r {{tmp_dir_path(run_id)}}',
-        trigger_rule='all_success'
-        )
+    t_create_tmpdir = CreateTmpDirOperator(task_id='create_temp_dir')
+    t_cleanup_tmpdir = CleanupTmpDirOperator(task_id='cleanup_temp_dir')
 
     def flex_maybe_spawn(**kwargs):
         """

--- a/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
+++ b/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
@@ -73,7 +73,7 @@ with HMDAG('scan_and_begin_processing',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('scan_and_begin_processing')
-           }
+           },
        ) as dag:
 
     def read_metadata_file(**kwargs):
@@ -248,5 +248,6 @@ with HMDAG('scan_and_begin_processing',
     (dag >> t_create_tmpdir >> t_run_validation >>
      t_maybe_continue >>
      t_run_md_extract >> t_md_consistency_tests >>
-     t_send_status >> t_maybe_spawn >> t_cleanup_tmpdir)
+     t_send_status >> t_maybe_spawn >> t_cleanup_tmpdir
+    )
     t_maybe_continue >> t_send_status

--- a/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
+++ b/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
@@ -73,8 +73,7 @@ with HMDAG('scan_and_begin_processing',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('scan_and_begin_processing')
-           },
-       ) as dag:
+           }) as dag:
 
     def read_metadata_file(**kwargs):
         md_fname = os.path.join(utils.get_tmp_dir_path(kwargs['run_id']),

--- a/src/ingest-pipeline/airflow/dags/test_aws_batch.py
+++ b/src/ingest-pipeline/airflow/dags/test_aws_batch.py
@@ -74,8 +74,7 @@ with HMDAG('test_aws_batch',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('test_aws_batch'),
-           },
-       ) as dag:
+           }) as dag:
 
     # def check_uuids(**kwargs):
     #     print('dag_run conf follows:')

--- a/src/ingest-pipeline/airflow/dags/test_aws_batch.py
+++ b/src/ingest-pipeline/airflow/dags/test_aws_batch.py
@@ -74,7 +74,7 @@ with HMDAG('test_aws_batch',
            user_defined_macros={
                'tmp_dir_path' : utils.get_tmp_dir_path,
                'preserve_scratch' : get_preserve_scratch_resource('test_aws_batch'),
-           }
+           },
        ) as dag:
 
     # def check_uuids(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/test_aws_batch.py
+++ b/src/ingest-pipeline/airflow/dags/test_aws_batch.py
@@ -28,6 +28,7 @@ from utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
+    get_preserve_scratch_resource,
 )
 
 
@@ -70,7 +71,10 @@ with HMDAG('test_aws_batch',
            schedule_interval=None, 
            is_paused_upon_creation=False, 
            default_args=default_args,
-           user_defined_macros={'tmp_dir_path' : utils.get_tmp_dir_path}
+           user_defined_macros={
+               'tmp_dir_path' : utils.get_tmp_dir_path,
+               'preserve_scratch' : get_preserve_scratch_resource('test_aws_batch'),
+           }
        ) as dag:
 
     # def check_uuids(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/test_workflow.py
+++ b/src/ingest-pipeline/airflow/dags/test_workflow.py
@@ -1,0 +1,68 @@
+import sys
+import os
+import ast
+import json
+from pathlib import Path
+from pprint import pprint
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.configuration import conf as airflow_conf
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.bash_operator import BashOperator
+from airflow.exceptions import AirflowException
+from airflow.hooks.http_hook import HttpHook
+
+from hubmap_operators.common_operators import (
+    CreateTmpDirOperator,
+    CleanupTmpDirOperator,
+)
+
+import utils
+from utils import (
+    get_tmp_dir_path, get_auth_tok,
+    map_queue_name, pythonop_get_dataset_state,
+    localized_assert_json_matches_schema as assert_json_matches_schema,
+    HMDAG,
+    get_queue_resource,
+    get_preserve_scratch_resource,
+    )
+
+# Following are defaults which can be overridden later on
+default_args = {
+    'owner': 'hubmap',
+    'depends_on_past': False,
+    'start_date': datetime(2019, 1, 1),
+    'email': ['joel.welling@gmail.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+    'xcom_push': True,
+    'queue': get_queue_resource('test_workflow'),
+}
+
+
+with HMDAG('test_workflow',
+           schedule_interval=None,
+           is_paused_upon_creation=False,
+           user_defined_macros={
+               'tmp_dir_path' : get_tmp_dir_path,
+               'preserve_scratch': get_preserve_scratch_resource('test_workflow'),
+           },
+           default_args=default_args,
+       ) as dag:
+
+    def test_task_func(**kwargs):
+        pprint(kwargs)
+
+    t_test = PythonOperator(
+        task_id='test_task',
+        python_callable=test_task_func,
+        provide_context=True,
+        )
+
+    t_create_tmpdir = CreateTmpDirOperator(task_id='create_tmp_dir')
+    t_cleanup_tmpdir = CleanupTmpDirOperator(task_id='cleanup_tmp_dir')
+
+    (dag >> t_create_tmpdir >> t_test >> t_cleanup_tmpdir)

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1363,6 +1363,16 @@ def get_lanes_resource(dag_id: str) -> int:
     return int(rec['lanes'])
 
 
+def get_preserve_scratch_resource(dag_id: str) -> bool:
+    """
+    Look up the number of lanes defined for this dag_id in the current
+    resource map.
+    """
+    rec = _lookup_resource_record(dag_id)
+    assert 'preserve_scratch' in rec, 'schema should guarantee "preserve_scratch" is present?'
+    return bool(rec['preserve_scratch'])
+
+
 def get_threads_resource(dag_id: str, task_id: Optional[str] = None) -> int:
     """
     Look up the number of threads defined for this dag_id and task_id in

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1301,15 +1301,17 @@ def _get_resource_map() -> List[Tuple[Pattern, Pattern, Dict[str, str]]]:
         cmp_map = []
         for dct in map['resource_map']:
             dag_re = re.compile(dct['dag_re'])
-            lanes = dct['lanes']
+            dag_dct = {key: dct[key] for key in dct
+                       if key not in ['dag_re', 'tasks']}
             tasks = []
-            for task_dct in dct['tasks']:
-                tasks.append({
-                    'task_re': re.compile(task_dct['task_re']),
-                    'queue': task_dct['queue'],
-                    'threads': task_dct['threads']
-                })
-            cmp_map.append((dag_re, lanes, tasks))
+            for inner_dct in dct['tasks']:
+                assert 'task_re' in inner_dct, ('schema should guarantee'
+                                                ' "task_re" is present?')
+                task_re = re.compile(inner_dct['task_re'])
+                task_dct = {key: inner_dct[key] for key in inner_dct
+                            if key not in ['task_re']}
+                tasks.append((task_re, task_dct))
+            cmp_map.append((dag_re, dag_dct, tasks))
         COMPILED_RESOURCE_MAP = cmp_map
     return COMPILED_RESOURCE_MAP
 
@@ -1322,19 +1324,18 @@ def _lookup_resource_record(dag_id: str,
     the dag_id is returned and only the information which is not task_id-specific
     is included.
     """
-    for dag_re, num_lanes, attr_dict_list in _get_resource_map():
+    for dag_re, dag_dict, task_list in _get_resource_map():
         if dag_re.match(dag_id):
-            if task_id is None:
-                return {'lanes': num_lanes}
-            else:
-                for attr_dict in attr_dict_list:
-                    assert 'task_re' in attr_dict, ('schema should guarantee'
-                                                    ' "task_re" is present?')
-                    if attr_dict['task_re'].match(task_id):
-                        rslt = {'lanes': num_lanes}
-                        rslt.update(attr_dict)
-                        del rslt['task_re']
-                        return rslt
+            rslt = dag_dict.copy()
+            if task_id is not None:
+                for task_re, task_dict in task_list:
+                    if task_re.match(task_id):
+                        rslt.update(task_dict)
+                        break
+                else:
+                    raise ValueError(f'Resource map entry for dag_id <{dag_id}>'
+                                     f' has no match for task_id <{task_id}>')
+            return rslt
     else:
         raise ValueError('No resource map entry found for'
                          f' dag_id <{dag_id}> task_id <{task_id}>')
@@ -1369,7 +1370,8 @@ def get_preserve_scratch_resource(dag_id: str) -> bool:
     resource map.
     """
     rec = _lookup_resource_record(dag_id)
-    assert 'preserve_scratch' in rec, 'schema should guarantee "preserve_scratch" is present?'
+    assert 'preserve_scratch' in rec, ('schema should guarantee'
+                                       ' "preserve_scratch" is present?')
     return bool(rec['preserve_scratch'])
 
 

--- a/src/ingest-pipeline/airflow/dags/workflow_map.yml
+++ b/src/ingest-pipeline/airflow/dags/workflow_map.yml
@@ -1,4 +1,7 @@
 workflow_map:
+  - 'collection_type': 'test_only'
+    'assay_type': '.*'
+    'workflow': 'test_workflow'
   - 'collection_type': 'devtest'
     'assay_type': '.*'
     'workflow': 'devtest_step2'

--- a/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
@@ -11,6 +11,7 @@ from utils import (
     get_dataset_uuid,
     pythonop_set_dataset_state,
     pythonop_trigger_target,
+    get_preserve_scratch_resource,
 )
 
 class LogInfoOperator(PythonOperator):
@@ -41,16 +42,23 @@ class CreateTmpDirOperator(BashOperator):
 class CleanupTmpDirOperator(BashOperator):
     @apply_defaults
     def __init__(self, **kwargs):
+        #kwargs['params']['message'] = str(kwargs)
+        # I managed to access this from within the bash cmd with 'echo {{params.message}}'
         super().__init__(
             bash_command="""
             tmp_dir="{{tmp_dir_path(run_id)}}" ; \
-            if [ -e "$tmp_dir/session.log" ] ; then
+            if [ -e "$tmp_dir/session.log" ] ; then \
               ds_dir="{{ti.xcom_pull(task_ids="send_create_dataset")}}" ; \
-              cp "$tmp_dir/session.log" "$ds_dir"  && echo rm -r "$tmp_dir" ; \
+              cp "$tmp_dir/session.log" "$ds_dir"  && echo copied session.log ; \
+            fi ; \
+            echo rmscratch is $rmscratch ; \
+            if [ "$rmscratch" = true ] ; then \
+              rm -r "$tmp_dir" ; \
             else \
-              echo rm -r "$tmp_dir" ; \
+              echo scratch directory was preserved ; \
             fi
             """,
+            env={'rmscratch':'{{"true" if preserve_scratch is defined and not preserve_scratch else "false"}}'},
             trigger_rule='all_success',
             **kwargs
             )

--- a/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
@@ -11,7 +11,6 @@ from utils import (
     get_dataset_uuid,
     pythonop_set_dataset_state,
     pythonop_trigger_target,
-    get_preserve_scratch_resource,
 )
 
 class LogInfoOperator(PythonOperator):
@@ -46,14 +45,14 @@ class CleanupTmpDirOperator(BashOperator):
             bash_command="""
             tmp_dir="{{tmp_dir_path(run_id)}}" ; \
             if [ -e "$tmp_dir/session.log" ] ; then \
-              ds_dir="{{ti.xcom_pull(task_ids="send_create_dataset")}}" ; \
-              cp "$tmp_dir/session.log" "$ds_dir"  && echo copied session.log ; \
+              ds_dir="{{ti.xcom_pull(task_ids='send_create_dataset')}}" ; \
+              cp "$tmp_dir/session.log" "$ds_dir"  && echo "copied session.log" ; \
             fi ; \
             echo rmscratch is $rmscratch ; \
             if [ "$rmscratch" = true ] ; then \
               rm -r "$tmp_dir" ; \
             else \
-              echo scratch directory was preserved ; \
+              echo "scratch directory was preserved" ; \
             fi
             """,
             env={'rmscratch':'{{"true" if preserve_scratch is defined and not preserve_scratch else "false"}}'},

--- a/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
@@ -42,8 +42,6 @@ class CreateTmpDirOperator(BashOperator):
 class CleanupTmpDirOperator(BashOperator):
     @apply_defaults
     def __init__(self, **kwargs):
-        #kwargs['params']['message'] = str(kwargs)
-        # I managed to access this from within the bash cmd with 'echo {{params.message}}'
         super().__init__(
             bash_command="""
             tmp_dir="{{tmp_dir_path(run_id)}}" ; \

--- a/src/ingest-pipeline/schemata/resource_map_schema.yml
+++ b/src/ingest-pipeline/schemata/resource_map_schema.yml
@@ -31,10 +31,13 @@
       'lanes':
         'type': 'integer'
         'description': 'Number of instances of this DAG to run simultaneously'
+      'preserve_scratch':
+        'type': 'boolean'
+        'description': 'True means do not delete scratch space at the end of execution'
       'tasks':
         'type': 'array'
         'items': {'$ref': '#/definitions/resource_map_task_record'}
-    'required': ['dag_re', 'lanes', 'tasks']
+    'required': ['dag_re', 'lanes', 'tasks', 'preserve_scratch']
 
   'resource_map':
     'type': 'array'


### PR DESCRIPTION
This PR provides a unified mechanism for controlling the deletion of scratch space.  Preservation of scratch is important for workflows that may need debugging, but wastes disk space for more stable DAGs.  Historically it has been controlled by disabling the deletion of scratch globally, with the necessary edits being carried across deployments by hand.  This update centralizes that control to the resource_map.yml file, which also controls queues and numbers of threads.  

The mechanism of function is:
* A boolean attribute, preserve_scratch, is added to resource_map.yml and to its schema
* A function get_preserve_scratch_resource() is added to utils.  Some other code improvements are made to the resource table code.
* Each DAG calls get_preserve_scratch_resource(dag_id) and associates the result with a macro.
* DAGs that previously used direct BashOperator code to create and remove scratch space are modified to use the common Create/CleanupTmpDirOperator code.
* CleanupTmpDirOperator is modified to respect the macro set by the calling DAG.

A new dag, test_workflow.py, was also added for testing purposes.

This resolves https://github.com/hubmapconsortium/ingest-pipeline/issues/137 but by a different mechanism.