### PR TITLE
Freeze airflow at 1.10.15 in requirements.txt

### DIFF
--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -5,7 +5,7 @@ prov==1.5.1
 tifffile
 xmltodict>=0.12.0
 pyimzml>=1.2.6
-apache-airflow[celery,crypto,postgres,redis,ssh]<2.0.0
+apache-airflow[celery,crypto,postgres,redis,ssh]==1.10.15
 airflow-multi-dagrun>=1.2,<2.0
 jsonschema==3.2.0
 fastjsonschema==2.14.2


### PR DESCRIPTION
This PR freezes Airflow at 1.10.15 in requirements.txt .  This has been the deployed version for a while, but leaving it unspecified was leading to undesirable version interpolation by pip when the environment was built.