### PR TITLE
The *segmentation tasks for celldive_deepcell need to run on a gpu

### DIFF
--- a/src/ingest-pipeline/airflow/dags/resource_map.yml
+++ b/src/ingest-pipeline/airflow/dags/resource_map.yml
@@ -13,6 +13,9 @@ resource_map:
     'preserve_scratch': true
     'lanes': 2
     'tasks':
+    - 'task_re': '.*segmentation'
+      'queue': 'gpu000_q1'
+      'threads': 6
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6


### PR DESCRIPTION
This change shifts the segmentation tasks of the celldive_deepcell pipeline to GPU hosts, which they need in order to run.