### PR TITLE
Modified survey.py and new_dataset_survey.py to get datasets from entity-api

### DIFF
--- a/src/ingest-pipeline/misc/tools/new_dataset_survey.py
+++ b/src/ingest-pipeline/misc/tools/new_dataset_survey.py
@@ -120,8 +120,11 @@ def main():
     main
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("uuid_txt",
-                        help="input .txt file containing uuids or .csv or .tsv file with uuid column")
+    parser.add_argument("uuid_txt", nargs="?",
+                        help=("Optional input .txt file containing uuids"
+                              " or .csv or .tsv file with uuid column."
+                              " The default is to get this data from entity-api."
+                          ))
     parser.add_argument("--out", help="name of the output .tsv file", required=True)
     parser.add_argument("--notes", action="append",
                         help=("merge dataset notes from this csv/tsv file"
@@ -131,7 +134,14 @@ def main():
     entity_factory = EntityFactory(auth_tok)
 
     uuid_l = []
-    if args.uuid_txt.endswith((".csv", ".tsv")):
+    if not args.uuid_txt:
+        in_df = entity_factory.fetch_new_dataset_table()
+        assert 'uuid' in in_df.columns, ('"uuid" column is missing from table'
+                                         ' provided by entity-api?')
+        uuid_key = 'uuid'
+        for elt in in_df['uuid']:
+            uuid_l.append(str(elt))
+    elif args.uuid_txt.endswith((".csv", ".tsv")):
         in_df = pd.read_csv(args.uuid_txt, engine="python", sep=None, 
                                dtype={'note': np.str}, encoding='utf-8-sig')
         if 'uuid' in in_df.columns:

--- a/src/ingest-pipeline/misc/tools/survey.py
+++ b/src/ingest-pipeline/misc/tools/survey.py
@@ -598,6 +598,24 @@ class EntityFactory:
         self.instance = instance or 'PROD'
         self.type_client = TypeClient(ENDPOINTS[self.instance]['assay_info_url'])
 
+    def fetch_new_dataset_table(self):
+        """
+        Fetches the records provided by the datasets/unpublished endpoint of
+        search-api for the current instance, and returns it as a Pandas DataFrame.
+        """
+        entity_url = ENDPOINTS[self.instance]['entity_url']
+        r = requests.get(f'{entity_url}/datasets/unpublished?format=json',
+                         headers={
+                             'Authorization': f'Bearer {self.auth_tok}',
+                             'Content-Type': 'application/json',
+                             'X-Hubmap-Application': 'ingest-pipeline'
+                              })
+        if r.status_code >= 300:
+            r.raise_for_status()
+        df = pd.DataFrame(r.json())  # that's all there is to it!
+        return df
+
+
     def get(self, uuid):
         """
         Returns an entity of some kind


### PR DESCRIPTION
This PR causes survey.py to get the list of uuids needed for new_dataset_survey from a newly deployed endpoint on entity-api, rather than from a spreadsheet explicitly downloaded from Neo4J.  This significantly simplifies the process of generating updates to the Unpublished Datasets spreadsheet.