### PR TITLE
Trivial changes to address a refactor of hubmap-commons

### DIFF
--- a/src/ingest-pipeline/misc/tools/regenerate_venv.sh
+++ b/src/ingest-pipeline/misc/tools/regenerate_venv.sh
@@ -3,7 +3,7 @@
 # This becomes the prompt of the created venv
 label=dev
 
-com_br=${COMMONS_BRANCH:-master}
+com_br=${COMMONS_BRANCH:-main}
 export COMMONS_BRANCH=${com_br}
 
 function get_dir_of_this_script () {

--- a/src/ingest-pipeline/misc/tools/test_create_dataset.py
+++ b/src/ingest-pipeline/misc/tools/test_create_dataset.py
@@ -7,8 +7,6 @@ from datetime import date
 import pandas as pd
 import numpy as np
 
-from hubmap_commons.globus_groups import get_globus_groups_info
-
 from survey import (Entity, Dataset, Sample, EntityFactory,
                     ROW_SORT_KEYS, column_sorter, is_uuid,
                     parse_text_list)
@@ -38,9 +36,6 @@ def main():
     direct_ancestors = ['HBM245.ZWNT.288']
     group_uuid = "5bd084c8-edc2-11e8-802f-0e368f3075e8"
     description = "This could in principle be a very long description"
-
-    globus_groups_info = get_globus_groups_info()
-
 
     direct_ancestor_uuids = [entity_factory.id_to_uuid(id) for id in direct_ancestors]
 


### PR DESCRIPTION
The only breaking change was the name change of the master branch, which becomes main.  get_globus_groups_info was referenced, but the data never actually got used in the current code, so that could just be deleted.