### PR TITLE
Parallelization on ingest validation test control

### DIFF
--- a/src/ingest-pipeline/airflow/dags/resource_map.yml
+++ b/src/ingest-pipeline/airflow/dags/resource_map.yml
@@ -9,6 +9,7 @@ resource_map:
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 1
+      'coreuse': 60
   - 'dag_re': 'celldive_deepcell'
     'preserve_scratch': true
     'lanes': 2
@@ -16,12 +17,15 @@ resource_map:
     - 'task_re': '.*segmentation'
       'queue': 'gpu000_q1'
       'threads': 6
+      'coreuse': 60
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
     - 'task_re': '.*cwl_segmentation'
       'queue': 'gpu000_q1'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'salmon_rnaseq_.*'
     'preserve_scratch': true
     'lanes': 2
@@ -30,6 +34,7 @@ resource_map:
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'generate_bdbag'
     'preserve_scratch': true
     'lanes': 1
@@ -37,6 +42,7 @@ resource_map:
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'generate_usage_report'
     'preserve_scratch': true
     'lanes': 1
@@ -44,6 +50,7 @@ resource_map:
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'codex_cytokit'
     'preserve_scratch': true
     'lanes': 2
@@ -52,9 +59,11 @@ resource_map:
     - 'task_re': '.*cwl_cytokit'
       'queue': 'gpu000_q1'
       'threads': 6
+      'coreuse': 60
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'ometiff_offset'
     'preserve_scratch': true
     'lanes': 2
@@ -63,6 +72,7 @@ resource_map:
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'launch_checksums'
     'preserve_scratch': true
     'lanes': 2
@@ -70,6 +80,7 @@ resource_map:
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'scan_and_begin_processing'
     'preserve_scratch': true
     'lanes': 2
@@ -77,9 +88,11 @@ resource_map:
     - 'task_re': 'run_validation'
       'queue': 'validate'
       'threads': 6
+      'coreuse': 60
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'validate_upload'
     'preserve_scratch': true
     'lanes': 2
@@ -87,9 +100,11 @@ resource_map:
     - 'task_re': 'run_validation'
       'queue': 'validate'
       'threads': 6
+      'coreuse': 60
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'validation_test'
     'preserve_scratch': true
     'lanes': 2
@@ -97,9 +112,11 @@ resource_map:
     - 'task_re': 'run_validation'
       'queue': 'validate'
       'threads': 6
+      'coreuse': 60
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': 'sc_atac_seq_.*'
     'preserve_scratch': true
     'lanes': 8
@@ -108,6 +125,7 @@ resource_map:
     - 'task_re': '.*'
       'queue': 'general'
       'threads': 6
+      'coreuse': 60
   - 'dag_re': '.*'
     'preserve_scratch': true
     'lanes': 2
@@ -115,3 +133,4 @@ resource_map:
       - 'task_re': '.*'
         'queue': 'general'
         'threads': 6
+        'coreuse': 60

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1396,6 +1396,15 @@ def get_threads_resource(dag_id: str, task_id: Optional[str] = None) -> int:
     return int(rec['threads'])
 
 
+def get_core_use_resource(dag_id: str, task_id: Optional[str] = None) -> int:
+    """
+    Look up the number of cores percentage to use as thread for parallel processing
+    """
+    rec = _lookup_resource_record(dag_id, task_id)
+    assert 'coreuse' in rec, 'schema should guarantee "coreuse" is present?'
+    return int(rec['coreuse'])
+
+
 def get_type_client() -> TypeClient:
     """
     Expose the type client instance publicly

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -26,6 +26,7 @@ from utils import (
     HMDAG,
     get_queue_resource,
     get_preserve_scratch_resource,
+    get_core_use_resource
     )
 
 sys.path.append(airflow_conf.as_dict()['connections']['SRC_PATH']
@@ -114,8 +115,9 @@ with HMDAG('validate_upload',
             dataset_ignore_globs=ignore_globs,
             upload_ignore_globs='*',
             plugin_directory=plugin_path,
-            #offline=True,  # noqa E265
-            add_notes=False
+            # offline=True,  # noqa E265
+            add_notes=False,
+            extra_parameters={'coreuse': get_core_use_resource('validate_upload')}
         )
         # Scan reports an error result
         report = ingest_validation_tools_error_report.ErrorReport(


### PR DESCRIPTION
New resource_map entry to control how many threads can the new parallel processing on gz validator plugin can make use of.