### PR TITLE
Add PROD env config files for CentOS 7 and RHEL 8.5

### DIFF
--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_prod.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_prod.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# HM_AF_METHOD must be one of venv, module_conda, or conda
+# HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
+HM_AF_METHOD='venv'
+HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm193-prod/venv'
+
+PARENTDIR="$(dirname "$(readlink -f "$0")")"
+. "${PARENTDIR}/airflow_environments/env_prod.sh"
+
+
+

--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_rhel_8.5_prod.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_rhel_8.5_prod.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# HM_AF_METHOD must be one of venv, module_conda, or conda
+# HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
+HM_AF_METHOD='conda'
+HM_AF_ENV_NAME='condaEnv_rhel_8.5_python_3.6_prod'
+
+PARENTDIR="$(dirname "$(readlink -f "$0")")"
+. "${PARENTDIR}/airflow_environments/env_prod.sh"
+
+
+


### PR DESCRIPTION
These are the PROD equivalents of existing config scripts for DEV and TEST.  They were created on the fly during deployment and need to be merged back into the repo.