### PR TITLE
Script to regenerate conda environment and associated issues

### DIFF
--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_dev.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_dev.sh
@@ -2,6 +2,9 @@
 
 # HM_AF_METHOD must be one of venv, module_conda, or conda
 # HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
+#HM_AF_METHOD='module_conda'
+#HM_AF_METHOD='conda'
+#HM_AF_ENV_NAME='condaEnv_centos_7_python_3.6_dev'
 HM_AF_METHOD='venv'
 HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm191-dev/venv'
 

--- a/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
@@ -84,13 +84,15 @@ for varname in "${envvars[@]}" ; do
 done
 
 if [ "${HM_AF_METHOD}" == 'conda' ] ; then
-    export PATH=/hive/users/hive/anaconda3/bin:%PATH
-    export LANG=C.UTF-8
-    export LC_ALL=C.UTF-8
+    which conda || export PATH=/hive/users/hive/anaconda3/bin:$PATH
+    #export LC_ALL=C.UTF-8
+    #export LANG=C.UTF-8
     eval "$(conda shell.bash hook)"
     conda activate "${HM_AF_ENV_NAME}"
 elif [ "${HM_AF_METHOD}" == 'module_conda' ] ; then
-    module load anaconda3
+    source /etc/profile.d/modules.sh
+    module use /hive/modulefiles
+    module load anaconda
     eval "$(conda shell.bash hook)"
     conda activate "${HM_AF_ENV_NAME}"
 elif [ "${HM_AF_METHOD}" == 'venv' ] ; then

--- a/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
@@ -71,8 +71,6 @@ done
 
 if [ "${HM_AF_METHOD}" == 'conda' ] ; then
     which conda || export PATH=/hive/users/hive/anaconda3/bin:$PATH
-    #export LC_ALL=C.UTF-8
-    #export LANG=C.UTF-8
     eval "$(conda shell.bash hook)"
     conda activate "${HM_AF_ENV_NAME}"
 elif [ "${HM_AF_METHOD}" == 'module_conda' ] ; then

--- a/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
@@ -5,10 +5,6 @@
 # allowed values of HUBMAP_INSTANCE
 hubmap_instance_strings=" prod test dev proto stage "
 
-# Path from top level to the airflow environments directory
-airflow_env_rel_path=src/ingest-pipeline/misc/tools/airflow_environments
-
-
 # function to find the path to this script
 function get_dir_of_this_script () {
     # This function sets DIR to the directory in which this script itself is found.
@@ -41,23 +37,13 @@ if [ $(contains "${hubmap_instance_strings}" "${instance}") == 0 ] ; then
    exit -1
 fi
 
-
 # set DIR to the directory of the current script, and find the source tree top level
 get_dir_of_this_script
 cd "$DIR"
 top_level_dir="$(git rev-parse --show-toplevel)"
 
 # establish OS context
-source /etc/os-release
-platform_string="${ID}_${VERSION_ID}_${instance}"
-platform_file="${top_level_dir}/${airflow_env_rel_path}/env_${platform_string}.sh"
-if [[ -e "${platform_file}" ]] ; then
-    source "${platform_file}"
-else
-    echo "Platform configuration file ${platform_file} does not exist"
-    exit -1
-fi
-
+source source_platform_file.sh
 
 # Handle setting of environment variables.
 #

--- a/src/ingest-pipeline/misc/tools/regenerate_conda_env.sh
+++ b/src/ingest-pipeline/misc/tools/regenerate_conda_env.sh
@@ -35,8 +35,6 @@ source source_platform_file.sh
 echo $HM_AF_METHOD $HM_AF_ENV_NAME
 if [ "${HM_AF_METHOD}" == 'conda' ] ; then
     which conda || export PATH=/hive/users/hive/anaconda3/bin:$PATH
-    #export LANG=C.UTF-8
-    #export LC_ALL=C.UTF-8
     eval "$(conda shell.bash hook)"
 elif [ "${HM_AF_METHOD}" == 'module_conda' ] ; then
     source /etc/profile.d/modules.sh

--- a/src/ingest-pipeline/misc/tools/regenerate_conda_env.sh
+++ b/src/ingest-pipeline/misc/tools/regenerate_conda_env.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+#set -x  # for logging and debugging
+
+# This specifies the instance of the environment to be created
+if [ -z "$HUBMAP_INSTANCE" ]; then
+    exit "The environment variable HUBMAP_INSTANCE is not set."
+fi
+instance="$HUBMAP_INSTANCE"
+
+# What python version should be used?
+python_version=3.6
+
+# Root directory for newly created conda environments
+conda_env_root="/opt/environments"
+
+function get_dir_of_this_script () {
+    # This function sets DIR to the directory in which this script itself is found.
+    # Thank you https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+    SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SCRIPT_SOURCE until the file is no longer a symlink
+	DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"
+	SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+	# if $SCRIPT_SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+	[[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$DIR/$SCRIPT_SOURCE" 
+    done
+    DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"
+    }
+
+get_dir_of_this_script  # sets $DIR
+cd $DIR
+
+source source_platform_file.sh
+
+echo $HM_AF_METHOD $HM_AF_ENV_NAME
+if [ "${HM_AF_METHOD}" == 'conda' ] ; then
+    which conda || export PATH=/hive/users/hive/anaconda3/bin:$PATH
+    #export LANG=C.UTF-8
+    #export LC_ALL=C.UTF-8
+    eval "$(conda shell.bash hook)"
+elif [ "${HM_AF_METHOD}" == 'module_conda' ] ; then
+    source /etc/profile.d/modules.sh
+    module use /hive/modulefiles
+    module load anaconda
+    eval "$(conda shell.bash hook)"
+else
+    echo "The config for this platform specifies a HM_AF_METHOD which is not one of 'conda' or 'module_conda'"
+    exit -1
+fi
+
+# Use the existing environment if it can be found
+conda_env_path=`conda env list | grep "${HM_AF_ENV_NAME}" | awk '{print $2}'`
+if [ "${conda_env_path}" == "" ]; then
+    if [ -e ${conda_env_root}/${HM_AF_ENV_NAME}/bin/python ]; then
+	conda_env_path=${conda_env_root}/${HM_AF_ENV_NAME}
+    fi
+fi
+
+# Create the environment if necessary
+if [ "${conda_env_path}" == "" ]; then
+    conda_env_path=${conda_env_root}/${HM_AF_ENV_NAME}
+    echo 'Creating the conda environment'
+    conda create --yes --prefix ${conda_env_path} python=${python_version} pip
+else
+    echo "Conda environment already exists"
+fi
+
+# Activate the environment
+conda activate ${conda_env_path}
+
+# Install requirements using pip
+pip install -r ../../requirements.txt
+

--- a/src/ingest-pipeline/misc/tools/source_platform_file.sh
+++ b/src/ingest-pipeline/misc/tools/source_platform_file.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+# Path to top level directory of repo
+if [ -z "${top_level_dir}" ]; then
+   top_level_dir="$(git rev-parse --show-toplevel)"
+fi
+
+# Path from top level to the airflow environments directory
+airflow_env_rel_path=src/ingest-pipeline/misc/tools/airflow_environments
+
+
+source /etc/os-release
+platform_string="${ID}_${VERSION_ID}_${instance}"
+platform_file="${top_level_dir}/${airflow_env_rel_path}/env_${platform_string}.sh"
+if [[ -e "${platform_file}" ]] ; then
+    source "${platform_file}"
+else
+    echo "Platform configuration file ${platform_file} does not exist"
+    exit -1
+fi
+

--- a/src/ingest-pipeline/misc/tools/source_platform_file.sh
+++ b/src/ingest-pipeline/misc/tools/source_platform_file.sh
@@ -8,7 +8,6 @@ fi
 # Path from top level to the airflow environments directory
 airflow_env_rel_path=src/ingest-pipeline/misc/tools/airflow_environments
 
-
 source /etc/os-release
 platform_string="${ID}_${VERSION_ID}_${instance}"
 platform_file="${top_level_dir}/${airflow_env_rel_path}/env_${platform_string}.sh"

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -1,4 +1,5 @@
 # git+https://github.com/hubmapconsortium/commons@main#egg=hubmap-commons==2.0.11
+jsonref>=0.2,<1.0
 hubmap-commons==2.0.14
 prov==1.5.1
 # pylibczi>=1.1.1


### PR DESCRIPTION
This PR addresses the following:
* Add a conda equivalent of the script regenerate_venv.sh
* Put the conda environment in /opt/environments
* Some common code between regenerate_conda_env and airflow_wrapper is moved to a separate script
Testing was performed under Airflow2 on DEV under both python3.6 and python3.9