### PR TITLE
Welling/diagnostics dag

### DIFF
--- a/src/ingest-pipeline/airflow/dags/.airflowignore
+++ b/src/ingest-pipeline/airflow/dags/.airflowignore
@@ -4,3 +4,6 @@ cwl
 obsolete
 utils.py
 workflow_map.yml
+resource_map.yml
+celery_queue_map.yml
+diagnostics

--- a/src/ingest-pipeline/airflow/dags/diagnose_failure.py
+++ b/src/ingest-pipeline/airflow/dags/diagnose_failure.py
@@ -1,5 +1,3 @@
-import sys
-import os
 import re
 from pathlib import Path
 from pprint import pprint
@@ -75,7 +73,7 @@ with HMDAG('diagnose_failure',
             raise AirflowException(f'Dataset {uuid} is not in Error state')
 
         if ('parent_dataset_uuid_list' in ds_rslt
-            and ds_rslt['parent_dataset_uuid_list'] is not None):
+                and ds_rslt['parent_dataset_uuid_list'] is not None):
             parent_dataset_full_path_list = []
             for parent_uuid in ds_rslt['parent_dataset_uuid_list']:
                 def parent_callable(**kwargs):
@@ -90,7 +88,7 @@ with HMDAG('diagnose_failure',
                     parent_ds_rslt['local_directory_full_path']
                 )
             ds_rslt['parent_dataset_full_path_list'] = parent_dataset_full_path_list
-            
+
         print(f"Finished uuid {ds_rslt['uuid']}")
         return ds_rslt  # causing it to be put into xcom
 

--- a/src/ingest-pipeline/airflow/dags/diagnose_failure.py
+++ b/src/ingest-pipeline/airflow/dags/diagnose_failure.py
@@ -1,0 +1,149 @@
+import sys
+import os
+import re
+from pathlib import Path
+from pprint import pprint
+from datetime import datetime, timedelta
+import logging
+
+from airflow.configuration import conf as airflow_conf
+from airflow.operators.python import PythonOperator
+from airflow.exceptions import AirflowException
+
+import utils
+from utils import (
+    localized_assert_json_matches_schema as assert_json_matches_schema,
+    HMDAG,
+    get_queue_resource,
+    )
+
+sys.path.append(airflow_conf.as_dict()['connections']['SRC_PATH']
+                .strip("'").strip('"'))
+from submodules import (ingest_validation_tools_upload,  # noqa E402
+                        ingest_validation_tools_error_report,
+                        ingest_validation_tests)
+sys.path.pop()
+
+FIND_SCRATCH_REGEX = r'/.+/scratch/[^/]+/'
+
+# Following are defaults which can be overridden later on
+default_args = {
+    'owner': 'hubmap',
+    'depends_on_past': False,
+    'start_date': datetime(2019, 1, 1),
+    'email': ['joel.welling@gmail.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+    'xcom_push': True,
+    'queue': get_queue_resource('validation_test'),
+}
+
+with HMDAG('diagnose_failure',
+           schedule_interval=None,
+           is_paused_upon_creation=False,
+           default_args=default_args,
+           ) as dag:
+
+    def find_uuid(**kwargs):
+        try:
+            assert_json_matches_schema(kwargs['dag_run'].conf,
+                                       'diagnose_failure_schema.yml')
+        except AssertionError:
+            print('invalid metadata follows:')
+            pprint(kwargs['dag_run'].conf)
+            raise
+
+        uuid = kwargs['dag_run'].conf['uuid']
+
+        def my_callable(**kwargs):
+            return uuid
+
+        ds_rslt = utils.pythonop_get_dataset_state(
+            dataset_uuid_callable=my_callable,
+            **kwargs
+        )
+        if not ds_rslt:
+            raise AirflowException(f'Invalid uuid/doi for group: {uuid}')
+        print('ds_rslt:')
+        pprint(ds_rslt)
+
+        for key in ['entity_type', 'status', 'uuid', 'data_types',
+                    'local_directory_full_path']:
+            assert key in ds_rslt, f"Dataset status for {uuid} has no {key}"
+
+        if not ds_rslt['entity_type'] in ['Dataset']:
+            raise AirflowException(f'Entity {uuid} is not a Dataset')
+
+        if not ds_rslt['status'] in ['Error']:
+            raise AirflowException(f'Dataset {uuid} is not in Error state')
+
+        lz_path = ds_rslt['local_directory_full_path']
+        uuid = ds_rslt['uuid']  # original 'uuid' may  actually be a DOI
+        print(f'Finished uuid {uuid}')
+        print(f'lz path: {lz_path}')
+        kwargs['ti'].xcom_push(value=ds_rslt)
+
+    t_find_uuid = PythonOperator(
+        task_id='find_uuid',
+        python_callable=find_uuid,
+        provide_context=True,
+        op_kwargs={
+            'crypt_auth_tok': (
+                utils.encrypt_tok(airflow_conf.as_dict()
+                                  ['connections']['APP_CLIENT_SECRET'])
+                .decode()
+                ),
+            }
+        )
+
+    def find_scratch(**kwargs):
+        info_dict = kwargs['ti'].xcom_pull().copy()
+        dir_path = Path(info_dict['local_directory_full_path'])
+        session_log_path = dir_path / 'session.log'
+        assert session_log_path.exists(), 'session.log is not in the dataset directory'
+        regex = re.compile(FIND_SCRATCH_REGEX)
+        scratch_path = None
+        for line in open(session_log_path):
+            match = regex.search(line)
+            if match:
+                scratch_path = match.group(0)
+                break
+        if scratch_path:
+            info_dict['scratch_path'] = scratch_path
+        kwargs['ti'].xcom_push(value=info_dict)
+
+    t_find_scratch = PythonOperator(
+        task_id='find_scratch',
+        python_callable=find_scratch,
+        provide_context=True,
+        op_kwargs={
+            'crypt_auth_tok': (
+                utils.encrypt_tok(airflow_conf.as_dict()
+                                  ['connections']['APP_CLIENT_SECRET'])
+                .decode()
+            ),
+        }
+    )
+
+    def run_diagnostics(**kwargs):
+        info_dict = kwargs['ti'].xcom_pull().copy()
+        for key in info_dict:
+            logging.info(f'{key.upper()}: {info_dict[key]}')
+        kwargs['ti'].xcom_push(value=info_dict)
+
+    t_run_diagnostics = PythonOperator(
+        task_id='run_plugin_diagnostics',
+        python_callable=run_plugin_diagnostics,
+        provide_context=True,
+        op_kwargs={
+            'crypt_auth_tok': (
+                utils.encrypt_tok(airflow_conf.as_dict()
+                                  ['connections']['APP_CLIENT_SECRET'])
+                .decode()
+            ),
+        }
+    )
+
+    t_find_uuid >> t_find_scratch >> t_run_diagnostics

--- a/src/ingest-pipeline/airflow/dags/diagnose_failure.py
+++ b/src/ingest-pipeline/airflow/dags/diagnose_failure.py
@@ -141,12 +141,12 @@ with HMDAG('diagnose_failure',
         plugin_path = Path(diagnostic_plugin.__file__).parent / 'plugins'
         for plugin in diagnostic_plugin.diagnostic_result_iter(plugin_path, **info_dict):
             diagnostic_result = plugin.diagnose()
-            if diagnostic_result.pass_fail():
-                logging.info(f'Plugin "{plugin.description}" found no problem')
-            else:
+            if diagnostic_result.problem_found():
                 logging.info(f'Plugin "{plugin.description}" found problems:')
                 for err_str in diagnostic_result.to_strings():
                     logging.info("    " + err_str)
+            else:
+                logging.info(f'Plugin "{plugin.description}" found no problem')
         return info_dict  # causing it to be put into xcom
 
     t_run_diagnostics = PythonOperator(

--- a/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
@@ -35,12 +35,12 @@ class DiagnosticResult():
     def __init__(self, string_list: List[str], **kwargs):
         self.string_list = string_list
 
-    def pass_fail(self) -> bool:
+    def problem_found(self) -> bool:
         """
-        a True return value means that the test was passed and the
+        a False return value means that the test was passed and the
         diagnostic did not detect a problem.
         """
-        return not self.string_list
+        return len(self.string_list) == 0
 
     def to_strings(self) -> List[str]:
         return self.string_list
@@ -71,12 +71,8 @@ class DiagnosticPlugin():
     def diagnose(self) -> DiagnosticResult:
         """
         Carries out the diagnostic test and returns a result.  "No Error" is
-        returned by returning a DiagnosticResult instance the pass_fail()
-        of which returns True.
-
-        "No error" is represented by returning an empty list.
-        If the assay_type is not one for which this validator is intended,
-        just return an empty list.
+        returned by returning a DiagnosticResult instance the problem_found()
+        of which returns False.
         """
         raise NotImplementedError()
 

--- a/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
@@ -53,7 +53,7 @@ class DiagnosticPlugin(object):
 
     order_of_application = 1.0
     """
-    A floating point value which determines the order in which tests are
+    float: A floating point value which determines the order in which tests are
     applied.  Low values are carried out sooner.
     """
 
@@ -96,6 +96,7 @@ def diagnostic_result_iter(plugin_dir: PathOrStr, **kwargs) -> Iterator[Diagnost
         raise DiagnosticError(f'{plugin_dir}/*.py does not match any diagnostic plugins')
 
     sort_me = []
+    this_dir = Path(__file__).parent
     with add_path(str(plugin_dir)):
         for fpath in plugin_dir.glob('*.py'):
             mod_nm = fpath.stem
@@ -112,7 +113,7 @@ def diagnostic_result_iter(plugin_dir: PathOrStr, **kwargs) -> Iterator[Diagnost
                 if (inspect.isclass(obj) and obj != DiagnosticPlugin
                     and issubclass(obj, DiagnosticPlugin)):
                     sort_me.append((obj.order_of_application, obj.description, obj))
-    sort_me.sort()
-    for order_of_application, description, cls in sort_me:
-        diagnostic_plugin = cls(**kwargs)
-        yield diagnostic_plugin
+        sort_me.sort()
+        for order_of_application, description, cls in sort_me:
+            diagnostic_plugin = cls(**kwargs)
+            yield diagnostic_plugin

--- a/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
@@ -31,7 +31,7 @@ class DiagnosticError(Exception):
     pass
 
 
-class DiagnosticResult(object):
+class DiagnosticResult():
     def __init__(self, string_list: List[str], **kwargs):
         self.string_list = string_list
 
@@ -41,12 +41,12 @@ class DiagnosticResult(object):
         diagnostic did not detect a problem.
         """
         return not self.string_list
-        
+
     def to_strings(self) -> List[str]:
         return self.string_list
 
 
-class DiagnosticPlugin(object):
+class DiagnosticPlugin():
     description = "This is a human-readable description"
     """str: human-readable description of the thing this plugin tests
     """
@@ -96,7 +96,6 @@ def diagnostic_result_iter(plugin_dir: PathOrStr, **kwargs) -> Iterator[Diagnost
         raise DiagnosticError(f'{plugin_dir}/*.py does not match any diagnostic plugins')
 
     sort_me = []
-    this_dir = Path(__file__).parent
     with add_path(str(plugin_dir)):
         for fpath in plugin_dir.glob('*.py'):
             mod_nm = fpath.stem
@@ -109,11 +108,11 @@ def diagnostic_result_iter(plugin_dir: PathOrStr, **kwargs) -> Iterator[Diagnost
                 mod = util.module_from_spec(spec)
                 sys.modules[mod_nm] = mod
                 spec.loader.exec_module(mod)  # type: ignore
-            for name, obj in inspect.getmembers(mod):
+            for _, obj in inspect.getmembers(mod):
                 if (inspect.isclass(obj) and obj != DiagnosticPlugin
-                    and issubclass(obj, DiagnosticPlugin)):
+                        and issubclass(obj, DiagnosticPlugin)):
                     sort_me.append((obj.order_of_application, obj.description, obj))
         sort_me.sort()
-        for order_of_application, description, cls in sort_me:
+        for _, _, cls in sort_me:
             diagnostic_plugin = cls(**kwargs)
             yield diagnostic_plugin

--- a/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
@@ -1,0 +1,118 @@
+import sys
+from importlib import util
+import inspect
+from typing import List, Union, Tuple, Iterator
+from pathlib import Path
+
+PathOrStr = Union[str, Path]
+
+KeyValuePair = Tuple[str, str]
+
+
+class add_path():
+    """
+    Add an element to sys.path using a context.
+    Thanks to Eugene Yarmash https://stackoverflow.com/a/39855753
+    """
+    def __init__(self, path):
+        self.path = path
+
+    def __enter__(self):
+        sys.path.insert(0, self.path)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            sys.path.remove(self.path)
+        except ValueError:
+            pass
+
+
+class DiagnosticError(Exception):
+    pass
+
+
+class DiagnosticResult(object):
+    def __init__(self, string_list: List[str], **kwargs):
+        self.string_list = string_list
+
+    def pass_fail(self) -> bool:
+        """
+        a True return value means that the test was passed and the
+        diagnostic did not detect a problem.
+        """
+        return not self.string_list
+        
+    def to_strings(self) -> List[str]:
+        return self.string_list
+
+
+class DiagnosticPlugin(object):
+    description = "This is a human-readable description"
+    """str: human-readable description of the thing this plugin tests
+    """
+
+    order_of_application = 1.0
+    """
+    A floating point value which determines the order in which tests are
+    applied.  Low values are carried out sooner.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        The general context is provided by keyword arguments. The
+        plugin is expected to test for the presence of the values
+        it needs and raise DiagnosticError if the necessary information
+        is not available.
+        """
+        if 'data_types' not in kwargs:
+            raise DiagnosticError('data_types info was not provided to constructor')
+        self.data_types = kwargs['data_types']
+
+    def diagnose(self) -> DiagnosticResult:
+        """
+        Carries out the diagnostic test and returns a result.  "No Error" is
+        returned by returning a DiagnosticResult instance the pass_fail()
+        of which returns True.
+
+        "No error" is represented by returning an empty list.
+        If the assay_type is not one for which this validator is intended,
+        just return an empty list.
+        """
+        raise NotImplementedError()
+
+
+def diagnostic_result_iter(plugin_dir: PathOrStr, **kwargs) -> Iterator[DiagnosticResult]:
+    """
+    Given a path to a directory of DiagnosticPlugins, iterate over the results of
+    applying all the plugins to the given kwargs.
+
+    plugin_dir: path to a directory containing classes derived from DiagnosticPlugin
+
+    returns an iterator the values of which are DiagnosticResult instances
+    """
+    plugin_dir = Path(plugin_dir)
+    plugins = list(plugin_dir.glob('*.py'))
+    if not plugins:
+        raise DiagnosticError(f'{plugin_dir}/*.py does not match any diagnostic plugins')
+
+    sort_me = []
+    with add_path(str(plugin_dir)):
+        for fpath in plugin_dir.glob('*.py'):
+            mod_nm = fpath.stem
+            if mod_nm in sys.modules:
+                mod = sys.modules[mod_nm]
+            else:
+                spec = util.spec_from_file_location(mod_nm, fpath)
+                if spec is None:
+                    raise DiagnosticError(f'bad plugin diagnostic {fpath}')
+                mod = util.module_from_spec(spec)
+                sys.modules[mod_nm] = mod
+                spec.loader.exec_module(mod)  # type: ignore
+            for name, obj in inspect.getmembers(mod):
+                if (inspect.isclass(obj) and obj != DiagnosticPlugin
+                    and issubclass(obj, DiagnosticPlugin)):
+                    sort_me.append((obj.order_of_application, obj.description, obj))
+    sort_me.sort()
+    for order_of_application, description, cls in sort_me:
+        diagnostic_plugin = cls(**kwargs)
+        yield diagnostic_plugin

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_fails_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_fails_plugin.py
@@ -7,8 +7,8 @@ from diagnostics.diagnostic_plugin import (
 )
 
 class AlwaysFailsDiagnosticResult(DiagnosticResult):
-    def pass_fail(self):
-        return False  # passes
+    def problem_found(self):
+        return True  # passes
 
     def to_strings(self):
         return ["This test failed because it always fails"]

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_fails_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_fails_plugin.py
@@ -1,0 +1,24 @@
+"""
+This test always fails.  It exists for development purposes.
+"""
+
+from diagnostics.diagnostic_plugin import (
+    DiagnosticPlugin, DiagnosticResult, DiagnosticError
+)
+
+class AlwaysFailsDiagnosticResult(DiagnosticResult):
+    def pass_fail(self):
+        return False  # passes
+
+    def to_strings(self):
+        return ["This test failed because it always fails"]
+
+class AlwaysFailsDiagnosticPlugin(DiagnosticPlugin):
+    description = "This test always fails"
+    order_of_application = 2.0
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def diagnose(self):
+        return AlwaysFailsDiagnosticResult([])

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_passes_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_passes_plugin.py
@@ -1,0 +1,19 @@
+"""
+This test always passes.  It exists for development purposes.
+"""
+
+from diagnostic_plugin import DiagnosticPlugin, DiagnosticResult, DiagnosticError
+
+class AlwaysPassesDiagnosticResult(DiagnosticResult):
+    def pass_fail(self):
+        return True  # passes
+
+    def to_strings(self):
+        return ["nothing to see here"]
+
+class AlwaysPassesDiagnosticPlugin(DiagnosticPlugin):
+    def __init__(self, **kwargs):
+        super.__init__(**kwargs)
+
+    def diagnose(self):
+        return AlwaysPassesDiagnosticResult([])

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_passes_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_passes_plugin.py
@@ -2,7 +2,9 @@
 This test always passes.  It exists for development purposes.
 """
 
-from diagnostic_plugin import DiagnosticPlugin, DiagnosticResult, DiagnosticError
+from diagnostics.diagnostic_plugin import (
+    DiagnosticPlugin, DiagnosticResult, DiagnosticError
+)
 
 class AlwaysPassesDiagnosticResult(DiagnosticResult):
     def pass_fail(self):
@@ -12,8 +14,11 @@ class AlwaysPassesDiagnosticResult(DiagnosticResult):
         return ["nothing to see here"]
 
 class AlwaysPassesDiagnosticPlugin(DiagnosticPlugin):
+    description = "This test always passes"
+    order_of_application = 1.0
+
     def __init__(self, **kwargs):
-        super.__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def diagnose(self):
         return AlwaysPassesDiagnosticResult([])

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_passes_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/always_passes_plugin.py
@@ -7,8 +7,8 @@ from diagnostics.diagnostic_plugin import (
 )
 
 class AlwaysPassesDiagnosticResult(DiagnosticResult):
-    def pass_fail(self):
-        return True  # passes
+    def problem_found(self):
+        return False  # passes
 
     def to_strings(self):
         return ["nothing to see here"]

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -878,12 +878,16 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
     if ds_rslt['entity_type'] == 'Dataset':
         assert 'data_types' in ds_rslt, f"Dataset status for {uuid} has no data_types"
         data_types = ds_rslt['data_types']
+        parent_dataset_uuid_list = [ancestor['uuid']
+                                    for ancestor in ds_rslt['direct_ancestors']
+                                    if ancestor['entity_type'] == 'Dataset']
         metadata = restructure_entity_metadata(ds_rslt)
         endpoint = f"datasets/{ds_rslt['uuid']}/file-system-abs-path"
     elif ds_rslt['entity_type'] == 'Upload':
         data_types = []
         metadata = {}
         endpoint = f"uploads/{ds_rslt['uuid']}/file-system-abs-path"
+        parent_dataset_uuid_list = None
     else:
         raise RuntimeError(f"Unknown entity_type {ds_rslt['entity_type']}")
     try:
@@ -909,6 +913,7 @@ def pythonop_get_dataset_state(**kwargs) -> JSONType:
         'entity_type': ds_rslt['entity_type'],
         'status': ds_rslt['status'],
         'uuid': ds_rslt['uuid'],
+        'parent_dataset_uuid_list': parent_dataset_uuid_list,
         'data_types': data_types,
         'local_directory_full_path': full_path,
         'metadata': metadata,

--- a/src/ingest-pipeline/schemata/diagnose_failure_schema.yml
+++ b/src/ingest-pipeline/schemata/diagnose_failure_schema.yml
@@ -1,0 +1,17 @@
+'$schema': 'http://json-schema.org/schema#'
+'$id': 'http://schemata.hubmapconsortium.org/diagnose_failure_schema.yml'
+'title': 'diagnose_failure metadata schema'
+'description': 'diagnose_failure metadata schema'
+
+'allOf': [{'$ref': '#/definitions/diagnose_failure'}]
+
+'definitions':
+
+  'diagnose_failure':
+     'type': 'object'
+     'properties':
+        'uuid':
+           'type': 'string'
+           'description': 'a dataset uuid or DOI'
+     'required': ['uuid']
+    


### PR DESCRIPTION
This PR contains a set of components needed to provide a DAG that can run a sequence of diagnostic tests on failed workflows.  The code components are:
* diagnose_failure.py is the runnable Airflow DAG itself
* diagnostics/diagnostic_plugin.py provides a simple plug-in architecture for the tests
* diagnostics/always_fails_plugin.py and always_passes_plugin.py provide tests of DAG behavior for failing and passing diagnostics
* schemata/diagnose_failure_schema.yml is the schema for the json required by the DAG

In addition, one utility is modified to add dataset parent information to a dict of dataset state info.

This PR has been tested on DEV.