### PR TITLE
Plugin to find error strings in session.log

### DIFF
--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
@@ -1,0 +1,57 @@
+"""
+This plugin uses regex to search for errors in session.log
+"""
+
+import re
+from pathlib import Path
+
+from diagnostics.diagnostic_plugin import (
+    DiagnosticPlugin,
+    DiagnosticResult,
+    DiagnosticError,
+)
+
+
+# TODO: maybe there's a way to encode case insensitivity directly into the regex string
+# rather than doing it in the combine method?
+
+# Finds all instances of the word "error"
+FIND_ERROR_REGEX = r"(\S+)?error(\S+)?"
+# Finds OSError and BrokenPipeError (test--TODO: needs better modularizing)
+FIND_IO_ERROR_REGEX = r"(oserror)|(brokenpipeerror)"
+
+
+class FindErrorsDiagnosticResult(DiagnosticResult):
+    def problem_found(self):
+        if len(self.string_list) > 0:
+            return True
+        return False
+
+    def to_strings(self):
+        print("Errors:")
+        for index, string in enumerate(self.string_list):
+            if index == 10:
+                break
+            print(string)
+        return self.string_list
+
+
+class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
+    description = "This test should locate instances of the string 'Error'"
+    order_of_application = 1.0
+
+    def __init__(self, **kwargs):
+        self.dir_path = Path(kwargs["local_directory_full_path"])
+
+    def diagnose(self):
+        session_log_path = self.dir_path / "session.log"
+        assert session_log_path.exists(), "session.log is not in the dataset directory"
+        regex = re.compile(FIND_IO_ERROR_REGEX, re.I)
+        errors = []
+        for line in open(session_log_path):
+            match = regex.search(line)
+            if match:
+                # TODO: Currently adds the entire line, could instead return just error name
+                # and/or do more parsing to separate error name and contextual info
+                errors.append(line)
+        return FindErrorsDiagnosticResult(errors)

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
@@ -10,14 +10,10 @@ from diagnostics.diagnostic_plugin import (
     DiagnosticResult,
 )
 
-
-# TODO: maybe there's a way to encode case insensitivity directly into the regex string
-# rather than doing it in the combine method? That is, if we want case insensitivity
-
 # Finds all instances of the word "error"
-FIND_ERROR_REGEX = r"(\S+)?error(\S+)?"
-# Finds OSError and BrokenPipeError (test--TODO: needs better modularizing)
-FIND_OS_ERROR_REGEX = r"(oserror)|(brokenpipeerror)"
+ERROR_REGEX = r"(?i)(\w+)?error(\w+)?"
+# Finds OSError or BrokenPipeError (TODO: needs better modularizing)
+OS_ERROR_REGEX = r"(OSError)|(BrokenPipeError)"
 
 
 class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
@@ -30,7 +26,7 @@ class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
     def diagnose(self):
         session_log_path = self.dir_path / "session.log"
         assert session_log_path.exists(), "session.log is not in the dataset directory"
-        regex = re.compile(FIND_ERROR_REGEX, re.I)
+        regex = re.compile(ERROR_REGEX)
         errors = []
         for line in open(session_log_path):
             match = regex.search(line)

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from diagnostics.diagnostic_plugin import (
     DiagnosticPlugin,
     DiagnosticResult,
-    DiagnosticError,
 )
 
 
@@ -27,10 +26,6 @@ class FindErrorsDiagnosticResult(DiagnosticResult):
             return True
         return False
 
-    def to_strings(self):
-        print("Errors:", len(self.string_list))
-        return self.string_list
-
 
 class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
     description = "This test should locate instances of the string 'Error'"
@@ -42,7 +37,7 @@ class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
     def diagnose(self):
         session_log_path = self.dir_path / "session.log"
         assert session_log_path.exists(), "session.log is not in the dataset directory"
-        regex = re.compile(FIND_OS_ERROR_REGEX, re.I)
+        regex = re.compile(FIND_ERROR_REGEX, re.I)
         errors = []
         for line in open(session_log_path):
             match = regex.search(line)

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
@@ -18,7 +18,7 @@ from diagnostics.diagnostic_plugin import (
 # Finds all instances of the word "error"
 FIND_ERROR_REGEX = r"(\S+)?error(\S+)?"
 # Finds OSError and BrokenPipeError (test--TODO: needs better modularizing)
-FIND_IO_ERROR_REGEX = r"(oserror)|(brokenpipeerror)"
+FIND_OS_ERROR_REGEX = r"(oserror)|(brokenpipeerror)"
 
 
 class FindErrorsDiagnosticResult(DiagnosticResult):
@@ -28,11 +28,7 @@ class FindErrorsDiagnosticResult(DiagnosticResult):
         return False
 
     def to_strings(self):
-        print("Errors:")
-        for index, string in enumerate(self.string_list):
-            if index == 10:
-                break
-            print(string)
+        print("Errors:", len(self.string_list))
         return self.string_list
 
 
@@ -46,7 +42,7 @@ class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
     def diagnose(self):
         session_log_path = self.dir_path / "session.log"
         assert session_log_path.exists(), "session.log is not in the dataset directory"
-        regex = re.compile(FIND_IO_ERROR_REGEX, re.I)
+        regex = re.compile(FIND_OS_ERROR_REGEX, re.I)
         errors = []
         for line in open(session_log_path):
             match = regex.search(line)

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
@@ -12,19 +12,12 @@ from diagnostics.diagnostic_plugin import (
 
 
 # TODO: maybe there's a way to encode case insensitivity directly into the regex string
-# rather than doing it in the combine method?
+# rather than doing it in the combine method? That is, if we want case insensitivity
 
 # Finds all instances of the word "error"
 FIND_ERROR_REGEX = r"(\S+)?error(\S+)?"
 # Finds OSError and BrokenPipeError (test--TODO: needs better modularizing)
 FIND_OS_ERROR_REGEX = r"(oserror)|(brokenpipeerror)"
-
-
-class FindErrorsDiagnosticResult(DiagnosticResult):
-    def problem_found(self):
-        if len(self.string_list) > 0:
-            return True
-        return False
 
 
 class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
@@ -45,4 +38,4 @@ class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
                 # TODO: Currently adds the entire line, could instead return just error name
                 # and/or do more parsing to separate error name and contextual info
                 errors.append(line)
-        return FindErrorsDiagnosticResult(errors)
+        return DiagnosticResult(errors)


### PR DESCRIPTION
This PR contains a plugin for the diagnose_failure DAG. This plugin uses regex to search for error strings and logs the lines with errors from session.log.

Note 1: The find_errors_plugin currently contains an override of FindErrorsDiagnosticResult.problem_found that may be unnecessary pending potential changes to parent class.

Note 2: I will name my branch better next time!