### PR TITLE
Fix an error in a base class method introduced in welling/diagnostics_dag

### DIFF
--- a/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/diagnostic_plugin.py
@@ -40,7 +40,7 @@ class DiagnosticResult():
         a False return value means that the test was passed and the
         diagnostic did not detect a problem.
         """
-        return len(self.string_list) == 0
+        return len(self.string_list) != 0
 
     def to_strings(self) -> List[str]:
         return self.string_list


### PR DESCRIPTION
Base class DiagnosticResult.problem_found() was returning False when error strings were present.  Should have been True.  This PR fixes that error.