### PR TITLE
Diagnose i/o errors

### DIFF
--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/find_errors_plugin.py
@@ -16,7 +16,7 @@ ERROR_REGEX = r"(?i)(\w+)?error(\w+)?"
 OS_ERROR_REGEX = r"(OSError)|(BrokenPipeError)"
 
 
-class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
+class ErrorsDiagnosticPlugin(DiagnosticPlugin):
     description = "This test should locate instances of the string 'Error'"
     order_of_application = 1.0
 

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
@@ -13,8 +13,8 @@ from diagnostics.diagnostic_plugin import (
 IO_ERROR_REGEX = r"(?=.*(OSError))(?=.*(Input\/output error))"
 
 
-class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
-    description = "This test should locate instances of the string 'Error'"
+class IOErrorsDiagnosticPlugin(DiagnosticPlugin):
+    description = "Detects input/output OSErrors"
     order_of_application = 1.0
 
     def __init__(self, **kwargs):

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
@@ -28,6 +28,6 @@ class IOErrorsDiagnosticPlugin(DiagnosticPlugin):
         for line in open(session_log_path):
             match = regex.search(line)
             if match:
+                errors.append("Input/output error found!")
                 errors.append(line)
-        print("Input/output error found!")
         return DiagnosticResult(errors)

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
@@ -28,7 +28,6 @@ class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
         for line in open(session_log_path):
             match = regex.search(line)
             if match:
-                # TODO: Currently adds the entire line, could instead return just error name
-                # and/or do more parsing to separate error name and contextual info
                 errors.append(line)
+        print("Input/output error found!")
         return DiagnosticResult(errors)

--- a/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/diagnostics/plugins/io_errors_plugin.py
@@ -1,0 +1,34 @@
+"""
+This plugin uses regex to search for IO errors in session.log
+"""
+
+import re
+from pathlib import Path
+
+from diagnostics.diagnostic_plugin import (
+    DiagnosticPlugin,
+    DiagnosticResult,
+)
+
+IO_ERROR_REGEX = r"(?=.*(OSError))(?=.*(Input\/output error))"
+
+
+class FindErrorsDiagnosticPlugin(DiagnosticPlugin):
+    description = "This test should locate instances of the string 'Error'"
+    order_of_application = 1.0
+
+    def __init__(self, **kwargs):
+        self.dir_path = Path(kwargs["local_directory_full_path"])
+
+    def diagnose(self):
+        session_log_path = self.dir_path / "session.log"
+        assert session_log_path.exists(), "session.log is not in the dataset directory"
+        regex = re.compile(IO_ERROR_REGEX)
+        errors = []
+        for line in open(session_log_path):
+            match = regex.search(line)
+            if match:
+                # TODO: Currently adds the entire line, could instead return just error name
+                # and/or do more parsing to separate error name and contextual info
+                errors.append(line)
+        return DiagnosticResult(errors)


### PR DESCRIPTION
This plugin parses session.log files to find lines containing BOTH the string "OSError" and "Input/output error" sequentially (case insensitive due to specificity of pattern). It then prints an error message. It has been tested on DEV.

Its functionality is otherwise identical to ErrorDiagnosticsPlugin, suggesting a potential later refactor.