### PR TITLE
Add opt limiting all java threads to get_cwltool_base_cmd

### DIFF
--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1059,8 +1059,10 @@ def get_cwltool_base_cmd(tmpdir: Path) -> List[str]:
     return [
         'env',
         'TMPDIR={}'.format(tmpdir),
+        '_JAVA_OPTIONS={}'.format('-XX:ActiveProcessorCount=2'),
         'cwltool',
         '--timestamps',
+        '--preserve-environment', '_JAVA_OPTIONS',
         # The trailing slashes in the next two lines are deliberate.
         # cwltool treats these path prefixes as *strings*, not as
         # directories in which new temporary dirs should be created, so


### PR DESCRIPTION
This PR adds the environment variable 
```
_JAVA_OPTIONS=-XX:ActiveProcessorCount=2
```
to all spawned CWL steps, which has the effect of making any java process spawned from that level think there are only 2 cores on its machine.  Since parallelism based on the threads= value is usually handled above the level of calls based on java (like bioformats tools), this gives about the right level of parallelism.

Another option would be
```
_JAVA_OPTIONS=-XX:ParallelGCThreads=2
```
which would only limit the GC threads.  This still allows other tasks (like actual work) to spawn as many threads as there are actual cores on the host, which might get more done but does allow some thread explosion.

Yet another option would be to set -XX:ActiveProcessorCount to the value of the threads= resource, but since the workflows tend to already use the threads= number to spawn multiple tasks that may be too many threads.