### PR TITLE
Update airflow_startup_scripts for Airflow 2

### DIFF
--- a/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_DEV_GPU.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_DEV_GPU.sh
@@ -13,6 +13,6 @@ logfile=${logdir}/${host}_${instance}
 nohup_file=${logdir}/nohup_${host}_${instance}.out
 
 nohup env HUBMAP_INSTANCE=${instance} \
-      ./airflow_wrapper.sh worker --queues $queue --concurrency $n \
-      --celery_hostname $name@$host \
+      ./airflow_wrapper.sh celery worker --queues $queue --concurrency $n \
+      -H $name@$host \
       --stdout ${logfile}.out --stderr ${logfile}.err --log-file ${logfile}.log > ${nohup_file}

--- a/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_PROD_EM.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_PROD_EM.sh
@@ -12,6 +12,6 @@ logfile=${logdir}/${host}_${instance}
 nohup_file=${logdir}/nohup_${host}_${instance}.out
 
 nohup env HUBMAP_INSTANCE=${instance} \
-      ./airflow_wrapper.sh worker --queues $queue --concurrency $n \
-      --celery_hostname $name@$host \
+      ./airflow_wrapper.sh celery worker --queues $queue --concurrency $n \
+      -H $name@$host \
       --stdout ${logfile}.out --stderr ${logfile}.err --log-file ${logfile}.log > ${nohup_file}

--- a/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_PROD_GPU.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_PROD_GPU.sh
@@ -13,6 +13,6 @@ logfile=${logdir}/${host}_${instance}
 nohup_file=${logdir}/nohup_${host}_${instance}.out
 
 nohup env HUBMAP_INSTANCE=${instance} \
-      ./airflow_wrapper.sh worker --queues $queue --concurrency $n \
-      --celery_hostname $name@$host \
+      ./airflow_wrapper.sh celery worker --queues $queue --concurrency $n \
+      -H $name@$host \
       --stdout ${logfile}.out --stderr ${logfile}.err --log-file ${logfile}.log > ${nohup_file}

--- a/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_TEST_GPU.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_startup_scripts/source_to_start_TEST_GPU.sh
@@ -13,6 +13,6 @@ logfile=${logdir}/${host}_${instance}
 nohup_file=${logdir}/nohup_${host}_${instance}.out
 
 nohup env HUBMAP_INSTANCE=${instance} \
-      ./airflow_wrapper.sh worker --queues $queue --concurrency $n \
-      --celery_hostname $name@$host \
+      ./airflow_wrapper.sh celery worker --queues $queue --concurrency $n \
+      -H $name@$host \
       --stdout ${logfile}.out --stderr ${logfile}.err --log-file ${logfile}.log > ${nohup_file}


### PR DESCRIPTION
This PR changes the Airflow command 'worker' to 'celery worker' and the operand --celery_hostname to -H