### PR TITLE
The [globus] block moves from app.cfg to airflow.cfg

### DIFF
--- a/src/ingest-pipeline/instance/app.cfg.example
+++ b/src/ingest-pipeline/instance/app.cfg.example
@@ -36,15 +36,5 @@ OUTPUT_GROUP_NAME = 'dataaccessgroup'
 # Optional template for use in customizing queue names, for better Celery sharing
 #QUEUE_NAME_TEMPLATE = '{}-test'
 
-[globus]
-app_client_id =
-app_client_secret =
-oauth_callback_route = /login
-# If you are running localhost, set this to http. Otherwise, set this to https.
-scheme = https
-# Should be a CSV of group names (not quote wrapped) that you would like to give access to
-# EX: group_1, group_2
-hubmap_groups = hubmap-data-admin, hubmap-data-curator
-
 [webserver]
 auth_backend = globus_auth.globus_auth


### PR DESCRIPTION
Remove the [globus] block from app.cfg.example, because it now goes in airflow.cfg .