### PR TITLE
Switch to Conda for all instances

### DIFF
--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_dev.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_dev.sh
@@ -2,11 +2,11 @@
 
 # HM_AF_METHOD must be one of venv, module_conda, or conda
 # HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
-#HM_AF_METHOD='module_conda'
-#HM_AF_METHOD='conda'
-#HM_AF_ENV_NAME='condaEnv_centos_7_python_3.6_dev'
-HM_AF_METHOD='venv'
-HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm191-dev/venv'
+# HM_AF_METHOD='module_conda'
+HM_AF_METHOD='conda'
+HM_AF_ENV_NAME='condaEnv_centos_7_python_3.6_dev'
+# HM_AF_METHOD='venv'
+# HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm191-dev/venv'
 
 PARENTDIR="$(dirname "$(readlink -f "$0")")"
 . "${PARENTDIR}/airflow_environments/env_dev.sh"

--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_prod.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_prod.sh
@@ -2,8 +2,10 @@
 
 # HM_AF_METHOD must be one of venv, module_conda, or conda
 # HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
-HM_AF_METHOD='venv'
-HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm193-prod/venv'
+HM_AF_METHOD='conda'
+HM_AF_ENV_NAME='condaEnv_centos_7_python_3.6_prod'
+# HM_AF_METHOD='venv'
+# HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm193-prod/venv'
 
 PARENTDIR="$(dirname "$(readlink -f "$0")")"
 . "${PARENTDIR}/airflow_environments/env_prod.sh"

--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_test.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_test.sh
@@ -2,8 +2,10 @@
 
 # HM_AF_METHOD must be one of venv, module_conda, or conda
 # HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
-HM_AF_METHOD='venv'
-HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm192-test/venv'
+HM_AF_METHOD='conda'
+HM_AF_ENV_NAME='condaEnv_centos_7_python_3.6_test'
+# HM_AF_METHOD='venv'
+# HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm192-test/venv'
 
 PARENTDIR="$(dirname "$(readlink -f "$0")")"
 . "${PARENTDIR}/airflow_environments/env_test.sh"


### PR DESCRIPTION
This PR activates the base conda environment for all the instances of ingest-pipeline, which eases the process of upgrading Python on future releases