### PR TITLE
General: Add an auto-deployment script to be used to sync changes to …

### DIFF
--- a/src/ingest-pipeline/misc/tools/auto_deploy.sh
+++ b/src/ingest-pipeline/misc/tools/auto_deploy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# What variables do we need?
+# Define HIVE machines
+#hive_machines=("gpu002", "l001")
+hive_machines=()
+#b2_machines=("v004.pvt.bridges2.psc.edu")
+b2_machines=()
+repo_env="dev"
+repo_dir="/opt/repositories/$(hostname -s)-$repo_env/ingest-pipeline"
+
+regenerate_env=false
+
+while getopts ":g" opt; do
+  case $opt in
+    g)
+      regenerate_env=true
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
+set -x
+for machine in ${hive_machines[@]}; do
+       	# Rsync repo to machine
+        rsync -a $repo_dir/ $machine:$repo_dir
+
+       	# If flag set, run the conda environment regenerations
+        if $regenerate_env ; then
+                ssh $machine "/usr/local/bin/update_hubmap.sh $repo_dir $repo_env"
+        fi
+done
+
+# Separate because its easier to loop twice over a small list than insert string checking and manipulation
+for machine in ${b2_machines[@]}; do
+        # Rsync repo to machine
+        rsync -a 'ssh -J bridges2.psc.edu' $repo_dir/ $machine:$repo_dir
+
+        # If flag set, run the conda environment regenerations
+        if $regenerate_env ; then
+                ssh -J "bridges2.psc.edu" $machine "/usr/local/bin/update_hubmap.sh $repo_dir $repo_env"
+        fi
+done


### PR DESCRIPTION
…files/environment from VMs to compute resources.


Note: This script has not been tested against B2 resources. This script can **only** be run against a node once that node has been brought in to puppet. This is because the /opt/repositores/{hostname}-{environment} path does not exist unless that deployment is run through puppet for the first time.