### PR TITLE
Welling/run background subtraction parallel control

### DIFF
--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -29,6 +29,7 @@ from utils import (
     HMDAG,
     get_queue_resource,
     get_preserve_scratch_resource,
+    get_threads_resource,
 )
 
 
@@ -188,7 +189,9 @@ with HMDAG('codex_cytokit',
             '--cytokit_output',
             data_dir / 'cytokit',
             '--slicing_pipeline_config',
-            data_dir / 'pipelineConfig.json'
+            data_dir / 'pipelineConfig.json',
+            '--num_concurrent_tasks",
+            get_threads_resource(dag.dag_id),
         ]
 
         return join_quote_command_str(command)

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -190,7 +190,7 @@ with HMDAG('codex_cytokit',
             data_dir / 'cytokit',
             '--slicing_pipeline_config',
             data_dir / 'pipelineConfig.json',
-            '--num_concurrent_tasks",
+            '--num_concurrent_tasks',
             get_threads_resource(dag.dag_id),
         ]
 

--- a/src/ingest-pipeline/airflow/dags/test_aws_batch.py
+++ b/src/ingest-pipeline/airflow/dags/test_aws_batch.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from airflow.providers.amazon.aws.operators.batch import AwsBatchOperator as AWSBatchOperator
+from airflow.providers.amazon.aws.operators.batch import BatchOperator as AWSBatchOperator
 
 import utils
 

--- a/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth_rbac.py
+++ b/src/ingest-pipeline/airflow/plugins/globus_auth/globus_auth_rbac.py
@@ -62,7 +62,7 @@ class CustomOAuthView(AuthOAuthView):
         self.globus_oauth.oauth2_start_flow(redirect_url)
 
         if 'code' not in request.args:
-            auth_uri = self.globus_oauth.oauth2_get_authorize_url(additional_params={
+            auth_uri = self.globus_oauth.oauth2_get_authorize_url(query_params={
                 "scope": "openid profile email urn:globus:auth:scope:transfer.api.globus.org:all "
                          "urn:globus:auth:scope:auth.globus.org:view_identities "
                          "urn:globus:auth:scope:groups.api.globus.org:all"})

--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_dev.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_centos_7_dev.sh
@@ -2,9 +2,9 @@
 
 # HM_AF_METHOD must be one of venv, module_conda, or conda
 # HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
-# HM_AF_METHOD='module_conda'
+#HM_AF_METHOD='module_conda'
 HM_AF_METHOD='conda'
-HM_AF_ENV_NAME='condaEnv_centos_7_python_3.6_dev'
+HM_AF_ENV_NAME='condaEnv_centos_7_python_3.9_dev'
 # HM_AF_METHOD='venv'
 # HM_AF_ENV_NAME='/hive/users/hive/hubmap/hivevm191-dev/venv'
 

--- a/src/ingest-pipeline/misc/tools/airflow_environments/env_rhel_8.5_dev.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_environments/env_rhel_8.5_dev.sh
@@ -3,7 +3,7 @@
 # HM_AF_METHOD must be one of venv, module_conda, or conda
 # HM_AF_ENV_NAME must be the name of the conda environment or the full path to the venv dir
 HM_AF_METHOD='conda'
-HM_AF_ENV_NAME='condaEnv_rhel_8.5_python_3.6_dev'
+HM_AF_ENV_NAME='condaEnv_rhel_8.5_python_3.9_dev'
 
 PARENTDIR="$(dirname "$(readlink -f "$0")")"
 . "${PARENTDIR}/airflow_environments/env_dev.sh"

--- a/src/ingest-pipeline/misc/tools/regenerate_conda_env.sh
+++ b/src/ingest-pipeline/misc/tools/regenerate_conda_env.sh
@@ -9,10 +9,11 @@ fi
 instance="$HUBMAP_INSTANCE"
 
 # What python version should be used?
-python_version=3.6
+python_version=3.9
 
 # Root directory for newly created conda environments
 conda_env_root="/opt/environments"
+# conda_env_root="/jet/home/hive/.conda/envs"
 
 function get_dir_of_this_script () {
     # This function sets DIR to the directory in which this script itself is found.

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -7,7 +7,7 @@ prov==1.5.1
 tifffile==2020.09.3
 xmltodict==0.13.0
 pyimzml==1.5.2
-apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.2.5
+apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.5.0
 airflow-multi-dagrun==2.3.1
 jsonschema==3.2.0
 fastjsonschema==2.16.2
@@ -17,17 +17,18 @@ PyYAML==6.0
 rdflib==5.0.0
 rdflib-jsonld==0.6.2
 Flask-OAuthlib==0.9.6
-dataclasses==0.8
+psycopg2-binary==2.9.5
+# dataclasses==0.8
 git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
 git+https://github.com/hubmapconsortium/fastq-utils@v0.2.5#egg=hubmap-fastq-utils
 # We need the dependencies of ingest-validation tools, but relative paths don't work
 # -r ${CWD}/submodules/ingest-validation-tools/requirements.txt
 tableschema==1.20.2
 goodtables==2.5.4
-globus-cli==1.12.0
+globus-cli==3.10.1
 yattag==1.14.0
 frictionless==4.0.0
-sqlalchemy==1.3.24
+sqlalchemy==1.4.15
 xmlschema==1.9.2
 WTForms==2.3.3
 hubmap_sdk==1.0.2
@@ -35,4 +36,5 @@ pandas==1.1.5
 authlib==0.15.6
 google-api-python-client==2.52.0
 google-auth-httplib2==0.1.0
-google-auth-oauthlib==0.5.3
+google-auth-oauthlib==0.8.0
+


### PR DESCRIPTION
**This branch cannot be deployed until a version of codex-pipeline downstream of both a4c9d72 and 4f78897 has been deployed**, since it invokes a command line argument added by those mods.  This branch adds a parameter to the invocation of codex-pipeline:run_background_subtraction.cwl in the codex_cytokit.py DAG which limits the amount of parallelism used by the Docker container in that step.  Previously parallelism was not specified so it defaulted to the number of cores on the node, which is not what we want.

This change does limit the parallelism in run_background_subtraction, which is the last unlimited bit of the DAG's invocation of the codex-pipeline repo.  It makes very little difference to running time in practice.  The parallelism of the SPRM repo is still unlimited, so the codex_cytokit DAG still presents parallelism problems.