### PR TITLE
Pipeline error catching

### DIFF
--- a/src/ingest-pipeline/airflow/dags/catch_pipeline_errors.py
+++ b/src/ingest-pipeline/airflow/dags/catch_pipeline_errors.py
@@ -16,100 +16,106 @@ TODO
 - type hinting
 """
 
+
 class FailureCallbackException(Exception):
     pass
 
 
 class FailureCallback:
+    """
+    List should be overwritten by each subclass with appropriate values.
+    """
+
+    external_exceptions = []
+    # TODO: Switch to curator email(s)
+    internal_email_recipients = ["gesina@psc.edu"]
+
+    def __init__(self, context, execute_methods=True):
+        self.context = context
+        self.uuid = self.context.get("task_instance").xcom_pull(key="uuid")
+        self.crypt_auth_tok = self.context.get("crypt_auth_tok")
+        self.dag_run = self.context.get("dag_run")
+        self.task = self.context.get("task")
+        self.exception = self.context.get("exception")
+        self.exception_name = type(self.exception).__name__
+
+        if execute_methods:
+            self.set_status()
+            self.send_failure_email()
+
+    # This is simplified from pythonop_get_dataset_state in utils
+    def get_submission_context(self):
+        method = "GET"
+        auth_tok = get_auth_tok(**{"crypt_auth_tok": self.crypt_auth_tok})
+        headers = {
+            "authorization": f"Bearer {auth_tok}",
+            "content-type": "application/json",
+            "X-Hubmap-Application": "ingest-pipeline",
+        }
+        http_hook = HttpHook(method, http_conn_id="ingest_api_connection")
+
+        endpoint = f"entities/{self.uuid}"
+
+        try:
+            response = http_hook.run(
+                endpoint, headers=headers, extra_options={"check_response": False}
+            )
+            response.raise_for_status()
+            submission_data = response.json()
+            return submission_data
+        except HTTPError as e:
+            print(f"ERROR: {e}")
+            if e.response.status_code == codes.unauthorized:
+                raise RuntimeError("entity database authorization was rejected?")
+            else:
+                print("benign error")
+                return {}
+
+    def get_status_and_message(self):
         """
-        List should be overwritten by each subclass with appropriate values.
+        Error message might need to be overwritten when
+        subclassed for various DAGs, so this is broken out.
         """
-        # Should probably be importing custom exceptions rather than comparing strings
-        external_exceptions = []
-        # TODO: Switch to curator email(s)
-        internal_email_recipients = ["gesina@psc.edu"]
+        return {
+            "status": "Invalid",
+            "validation_message": f"Process {self.dag_run.dag_id} started {self.dag_run.execution_date} failed at task {self.task.task_id} with error {self.exception_name} {self.exception}",
+        }
 
-        def __init__(self, context, execute_methods=True):
-            self.context = context
-            self.uuid = self.context.get("task_instance").xcom_pull(key="uuid")
-            self.crypt_auth_tok = self.context.get("crypt_auth_tok")
-            self.dag_run = self.context.get("dag_run")
-            self.task = self.context.get("task")
-            self.exception = self.context.get("exception")
-            self.exception_name = type(self.exception).__name__
+    def set_status(self):
+        """
+        The failure callback needs to set the
+        dataset status.
+        """
+        data = self.get_status_and_message()
+        auth_tok = get_auth_tok(**{"crypt_auth_tok": self.crypt_auth_tok})
+        endpoint = f"/entities/{self.uuid}"
+        headers = {
+            "authorization": "Bearer " + auth_tok,
+            "X-Hubmap-Application": "ingest-pipeline",
+            "content-type": "application/json",
+        }
+        extra_options = []
+        http_conn_id = "entity_api_connection"
+        http_hook = HttpHook("PUT", http_conn_id=http_conn_id)
+        print("data: ")
+        pprint(data)
+        response = http_hook.run(
+            endpoint,
+            json.dumps(data),
+            headers,
+            extra_options,
+        )
 
-            if execute_methods:
-                    self.set_status()
-                    self.send_failure_email()
-
-        # This is simplified from pythonop_get_dataset_state in utils
-        def get_submission_context(self):
-            method = 'GET'
-            auth_tok = get_auth_tok(**{"crypt_auth_tok": self.crypt_auth_tok})
-            headers = {
-                'authorization': f'Bearer {auth_tok}',
-                'content-type': 'application/json',
-                'X-Hubmap-Application': 'ingest-pipeline',
-            }
-            http_hook = HttpHook(method, http_conn_id='ingest_api_connection')
-
-            endpoint = f'entities/{self.uuid}'
-
-            try:
-                response = http_hook.run(endpoint,
-                    headers=headers,
-                    extra_options={'check_response': False})
-                response.raise_for_status()
-                submission_data = response.json()
-                return submission_data
-            except HTTPError as e:
-                print(f'ERROR: {e}')
-                if e.response.status_code == codes.unauthorized:
-                    raise RuntimeError('entity database authorization was rejected?')
-                else:
-                    print('benign error')
-                    return {}
-
-        def get_status_and_message(self):
-             """
-             Error message might need to be overwritten when
-             subclassed for various DAGs, so this is broken out.
-             """
-             return {"status": "Invalid", "validation_message": f"Process {self.dag_run.dag_id} started {self.dag_run.execution_date} failed at task {self.task.task_id} with error {self.exception_name} {self.exception}"}
-
-        def set_status(self):
-             """
-             The failure callback needs to set the
-             dataset status.
-             """
-             data = self.get_status_and_message()
-             auth_tok = get_auth_tok(**{"crypt_auth_tok": self.crypt_auth_tok})
-             endpoint = f"/entities/{self.uuid}"
-             headers = {
-                 "authorization": "Bearer " + auth_tok,
-                 "X-Hubmap-Application": "ingest-pipeline",
-                 "content-type": "application/json",
-             }
-             extra_options = []
-             http_conn_id = "entity_api_connection"
-             http_hook = HttpHook("PUT", http_conn_id=http_conn_id)
-             print("data: ")
-             pprint(data)
-             response = http_hook.run(
-                 endpoint,
-                 json.dumps(data),
-                 headers,
-                 extra_options,
-             )
-
-         def get_failure_email_template(self, formatted_exception=None, external_template=False, submission_data=None, **kwargs):
-             """
-             Generic template, can be overridden or super() called
-             in subclass.
-             """
-             subject = f"DAG {self.dag_run.dag_id} failed at task {self.task.task_id}"
-             if formatted_exception:
-                     msg = f"""
+    def get_failure_email_template(
+        self, formatted_exception=None, external_template=False, submission_data=None, **kwargs
+    ):
+        """
+        Generic template, can be overridden or super() called
+        in subclass.
+        """
+        subject = f"DAG {self.dag_run.dag_id} failed at task {self.task.task_id}"
+        if formatted_exception:
+            msg = f"""
                              DAG run: {self.dag_run.id} {self.dag_run.dag_id} <br>
                              Task: {self.task.task_id} <br>
                              Execution date: {self.dag_run.execution_date} <br>
@@ -118,29 +124,40 @@ class FailureCallback:
                              Traceback: {formatted_exception}
                             """
 
-             else:
-                     msg = f"""
+        else:
+            msg = f"""
                              DAG run: {self.dag_run.id} {self.dag_run.dag_id} <br>
                              Task: {self.task.task_id} <br>
                              Execution date: {self.dag_run.execution_date} <br>
                              Run id: {self.dag_run.run_id} <br>
                              Error: {self.exception_name} <br>
                              """
-             return subject, msg
+        return subject, msg
 
-        def send_failure_email(self, **kwargs):
-             # traceback logic borrowed from https://stackoverflow.com/questions/51822029/get-exception-details-on-airflow-on-failure-callback-context
-             try:
-                 formatted_exception = "".join(traceback.TracebackException.from_exception(self.exception).format()).replace("\n", "<br>")
-             except:
-                 formatted_exception = None
-             self.submission_data = self.get_submission_context()
-             subject, msg = self.get_failure_email_template(formatted_exception=formatted_exception, submission_data=self.submission_data, **kwargs)
-             send_email(to=[self.internal_email_recipients], subject=subject, html_content=msg)
-             if self.exception_name in self.external_exceptions:
-                 try:
-                     created_by_user_email = self.submission_data.get("created_by_user_email")
-                     subject, msg = self.get_failure_email_template(formatted_exception=formatted_exception, external_template=True, submission_data=self.submission_data, **kwargs)
-                     send_email(to=[created_by_user_email], subject=subject, html_content=msg)
-                 except:
-                     raise FailureCallbackException("Failure retrieving created_by_user_email or sending email.")
+    def send_failure_email(self, **kwargs):
+        # traceback logic borrowed from https://stackoverflow.com/questions/51822029/get-exception-details-on-airflow-on-failure-callback-context
+        try:
+            formatted_exception = "".join(
+                traceback.TracebackException.from_exception(self.exception).format()
+            ).replace("\n", "<br>")
+        except:
+            formatted_exception = None
+        self.submission_data = self.get_submission_context()
+        subject, msg = self.get_failure_email_template(
+            formatted_exception=formatted_exception, submission_data=self.submission_data, **kwargs
+        )
+        send_email(to=self.internal_email_recipients, subject=subject, html_content=msg)
+        if self.exception_name in self.external_exceptions:
+            try:
+                created_by_user_email = self.submission_data.get("created_by_user_email")
+                subject, msg = self.get_failure_email_template(
+                    formatted_exception=formatted_exception,
+                    external_template=True,
+                    submission_data=self.submission_data,
+                    **kwargs,
+                )
+                send_email(to=[created_by_user_email], subject=subject, html_content=msg)
+            except:
+                raise FailureCallbackException(
+                    "Failure retrieving created_by_user_email or sending email."
+                )

--- a/src/ingest-pipeline/airflow/dags/catch_pipeline_errors.py
+++ b/src/ingest-pipeline/airflow/dags/catch_pipeline_errors.py
@@ -1,0 +1,146 @@
+import json
+from pprint import pprint
+from requests.exceptions import HTTPError
+from requests import codes
+import traceback
+
+from airflow.providers.http.hooks.http import HttpHook
+from airflow.utils.email import send_email
+
+from utils import get_auth_tok
+
+"""
+TODO
+- this requires crypt_auth_tok to be an op_kwarg, is that reasonable?
+- fix DRY issues (e.g. get_submission_context?, set_status)
+- type hinting
+"""
+
+class FailureCallbackException(Exception):
+    pass
+
+
+class FailureCallback:
+        """
+        List should be overwritten by each subclass with appropriate values.
+        """
+        # Should probably be importing custom exceptions rather than comparing strings
+        external_exceptions = []
+        # TODO: Switch to curator email(s)
+        internal_email_recipients = ["gesina@psc.edu"]
+
+        def __init__(self, context, execute_methods=True):
+            self.context = context
+            self.uuid = self.context.get("task_instance").xcom_pull(key="uuid")
+            self.crypt_auth_tok = self.context.get("crypt_auth_tok")
+            self.dag_run = self.context.get("dag_run")
+            self.task = self.context.get("task")
+            self.exception = self.context.get("exception")
+            self.exception_name = type(self.exception).__name__
+
+            if execute_methods:
+                    self.set_status()
+                    self.send_failure_email()
+
+        # This is simplified from pythonop_get_dataset_state in utils
+        def get_submission_context(self):
+            method = 'GET'
+            auth_tok = get_auth_tok(**{"crypt_auth_tok": self.crypt_auth_tok})
+            headers = {
+                'authorization': f'Bearer {auth_tok}',
+                'content-type': 'application/json',
+                'X-Hubmap-Application': 'ingest-pipeline',
+            }
+            http_hook = HttpHook(method, http_conn_id='ingest_api_connection')
+
+            endpoint = f'entities/{self.uuid}'
+
+            try:
+                response = http_hook.run(endpoint,
+                    headers=headers,
+                    extra_options={'check_response': False})
+                response.raise_for_status()
+                submission_data = response.json()
+                return submission_data
+            except HTTPError as e:
+                print(f'ERROR: {e}')
+                if e.response.status_code == codes.unauthorized:
+                    raise RuntimeError('entity database authorization was rejected?')
+                else:
+                    print('benign error')
+                    return {}
+
+        def get_status_and_message(self):
+             """
+             Error message might need to be overwritten when
+             subclassed for various DAGs, so this is broken out.
+             """
+             return {"status": "Invalid", "validation_message": f"Process {self.dag_run.dag_id} started {self.dag_run.execution_date} failed at task {self.task.task_id} with error {self.exception_name} {self.exception}"}
+
+        def set_status(self):
+             """
+             The failure callback needs to set the
+             dataset status.
+             """
+             data = self.get_status_and_message()
+             auth_tok = get_auth_tok(**{"crypt_auth_tok": self.crypt_auth_tok})
+             endpoint = f"/entities/{self.uuid}"
+             headers = {
+                 "authorization": "Bearer " + auth_tok,
+                 "X-Hubmap-Application": "ingest-pipeline",
+                 "content-type": "application/json",
+             }
+             extra_options = []
+             http_conn_id = "entity_api_connection"
+             http_hook = HttpHook("PUT", http_conn_id=http_conn_id)
+             print("data: ")
+             pprint(data)
+             response = http_hook.run(
+                 endpoint,
+                 json.dumps(data),
+                 headers,
+                 extra_options,
+             )
+
+         def get_failure_email_template(self, formatted_exception=None, external_template=False, submission_data=None, **kwargs):
+             """
+             Generic template, can be overridden or super() called
+             in subclass.
+             """
+             subject = f"DAG {self.dag_run.dag_id} failed at task {self.task.task_id}"
+             if formatted_exception:
+                     msg = f"""
+                             DAG run: {self.dag_run.id} {self.dag_run.dag_id} <br>
+                             Task: {self.task.task_id} <br>
+                             Execution date: {self.dag_run.execution_date} <br>
+                             Run id: {self.dag_run.run_id} <br>
+                             Error: {self.exception_name} <br>
+                             Traceback: {formatted_exception}
+                            """
+
+             else:
+                     msg = f"""
+                             DAG run: {self.dag_run.id} {self.dag_run.dag_id} <br>
+                             Task: {self.task.task_id} <br>
+                             Execution date: {self.dag_run.execution_date} <br>
+                             Run id: {self.dag_run.run_id} <br>
+                             Error: {self.exception_name} <br>
+                             """
+             return subject, msg
+
+        def send_failure_email(self, **kwargs):
+             # traceback logic borrowed from https://stackoverflow.com/questions/51822029/get-exception-details-on-airflow-on-failure-callback-context
+             try:
+                 formatted_exception = "".join(traceback.TracebackException.from_exception(self.exception).format()).replace("\n", "<br>")
+             except:
+                 formatted_exception = None
+             self.submission_data = self.get_submission_context()
+             subject, msg = self.get_failure_email_template(formatted_exception=formatted_exception, submission_data=self.submission_data, **kwargs)
+             send_email(to=[self.internal_email_recipients], subject=subject, html_content=msg)
+             if self.exception_name in self.external_exceptions:
+                 try:
+                     created_by_user_email = self.submission_data.get("created_by_user_email")
+                     subject, msg = self.get_failure_email_template(formatted_exception=formatted_exception, external_template=True, submission_data=self.submission_data, **kwargs)
+                     send_email(to=[created_by_user_email], subject=subject, html_content=msg)
+                 except:
+                     raise FailureCallbackException("Failure retrieving created_by_user_email or sending email.")

--- a/src/ingest-pipeline/airflow/dags/error_catching/failure_callback.py
+++ b/src/ingest-pipeline/airflow/dags/error_catching/failure_callback.py
@@ -9,13 +9,6 @@ from airflow.utils.email import send_email
 
 from utils import get_auth_tok
 
-"""
-TODO
-- this requires crypt_auth_tok to be an op_kwarg, is that reasonable?
-- fix DRY issues (e.g. get_submission_context?, set_status)
-- type hinting
-"""
-
 
 class FailureCallbackException(Exception):
     pass
@@ -32,7 +25,7 @@ class FailureCallback:
     def __init__(self, context, execute_methods=True):
         self.context = context
         self.uuid = self.context.get("task_instance").xcom_pull(key="uuid")
-        self.auth_tok = get_auth_tok(**{"crypt_auth_tok": self.context.get("crypt_auth_tok")})
+        self.auth_tok = get_auth_tok(**context)
         self.dag_run = self.context.get("dag_run")
         self.task = self.context.get("task")
         self.exception = self.context.get("exception")
@@ -58,7 +51,7 @@ class FailureCallback:
             "content-type": "application/json",
             "X-Hubmap-Application": "ingest-pipeline",
         }
-        http_hook = HttpHook(method, http_conn_id="ingest_api_connection")
+        http_hook = HttpHook(method, http_conn_id="entity_api_connection")
 
         endpoint = f"entities/{self.uuid}"
 
@@ -164,7 +157,7 @@ class FailureCallback:
                 send_email(to=[created_by_user_email], subject=subject, html_content=msg)
             except:
                 raise FailureCallbackException(
-FailureCallbackException"Failure retrieving created_by_user_email or sending email."
+                        "Failure retrieving created_by_user_email or sending email."
                 )
 
     def send_asana_notification(self, **kwargs):

--- a/src/ingest-pipeline/airflow/dags/error_catching/validate_upload_failure_callback.py
+++ b/src/ingest-pipeline/airflow/dags/error_catching/validate_upload_failure_callback.py
@@ -1,0 +1,54 @@
+from airflow.utils.email import send_email
+
+from failure_callback import FailureCallback, FailureCallbackException
+
+
+class ValidateUploadFailure(FailureCallback):
+    # Should probably be importing custom exceptions rather than comparing strings
+    external_exceptions = [
+        "ValueError",
+        "PreflightError",
+        "ValidatorError",
+        "DirectoryValidationErrors",
+        "FileNotFoundError",
+    ]
+
+    def get_failure_email_template(
+        self,
+        formatted_exception=None,
+        external_template=False,
+        submission_data=None,
+        report_txt=False,
+    ):
+        if external_template:
+            if report_txt and submission_data:
+                subject = f"Your {submission_data.get('entity_type')} has failed!"
+                msg = f"""
+                    Error: {report_txt}
+                    """
+                return subject, msg
+        else:
+            if report_txt and submission_data:
+                subject = f"{submission_data.get('entity_type')} {self.uuid} has failed!"
+                msg = f"""
+                    Error: {report_txt}
+                    """
+                return subject, msg
+        return super().get_failure_email_template(formatted_exception)
+
+    def send_failure_email(self, **kwargs):
+        super().send_failure_email(**kwargs)
+        if "report_txt" in kwargs:
+            try:
+                created_by_user_email = self.submission_data.get("created_by_user_email")
+                subject, msg = self.get_failure_email_template(
+                    formatted_exception=None,
+                    external_template=True,
+                    submission_data=self.submission_data,
+                    **kwargs,
+                )
+                send_email(to=[created_by_user_email], subject=subject, html_content=msg)
+            except:
+                raise FailureCallbackException(
+                    "Failure retrieving created_by_user_email or sending email in ValidateUploadFailure."
+                )

--- a/src/ingest-pipeline/airflow/dags/error_catching/validate_upload_failure_callback.py
+++ b/src/ingest-pipeline/airflow/dags/error_catching/validate_upload_failure_callback.py
@@ -1,6 +1,6 @@
 from airflow.utils.email import send_email
 
-from failure_callback import FailureCallback, FailureCallbackException
+from .failure_callback import FailureCallback, FailureCallbackException
 
 
 class ValidateUploadFailure(FailureCallback):

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -39,6 +39,7 @@ sys.path.pop()
 
 
 class ValidateUploadFailure(FailureCallback):
+    # Should probably be importing custom exceptions rather than comparing strings
     external_exceptions = [
         "ValueError",
         "PreflightError",

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -1,6 +1,7 @@
 import sys
 
 import json
+import traceback
 from pathlib import Path
 from datetime import datetime, timedelta
 from pprint import pprint
@@ -9,6 +10,7 @@ from airflow.configuration import conf as airflow_conf
 from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
+from airflow.utils.email import send_email
 
 from hubmap_operators.common_operators import (
     CreateTmpDirOperator,
@@ -16,144 +18,201 @@ from hubmap_operators.common_operators import (
 )
 
 from utils import (
-    get_tmp_dir_path, get_auth_tok,
+    encrypt_tok,
+    get_tmp_dir_path,
+    get_auth_tok,
     pythonop_get_dataset_state,
     HMDAG,
     get_queue_resource,
     get_preserve_scratch_resource,
-    get_threads_resource
+    get_threads_resource,
+)
+
+sys.path.append(airflow_conf.as_dict()["connections"]["SRC_PATH"].strip("'").strip('"'))
+from submodules import (
+    ingest_validation_tools_upload,  # noqa E402
+    ingest_validation_tools_error_report,
+    ingest_validation_tests,
+)
+
+sys.path.pop()
+
+
+def failure_email_function(context):
+    # traceback logic borrowed from https://stackoverflow.com/questions/51822029/get-exception-details-on-airflow-on-failure-callback-context
+    dag_run = context.get("dag_run")
+    exception = context.get("exception")
+    formatted_exception = "".join(
+        traceback.format_exception(
+            etype=type(exception), value=exception, tb=exception.__traceback__
+        )
+    ).strip()
+    subject = f"DAG {context.get('dag')} failed at task {context.get('task')}"
+    msg = f"""DAG run: {dag_run}
+            Error: {exception}
+            Traceback: {formatted_exception}"""
+    send_email(to=["gesina@psc.edu"], subject=subject, html_content=msg)
+
+    """
+    It looks like a failure callback will need to manually set the
+    dataset status. That's what this does.
+
+    Recycling the send_status task would be better but
+    it requires all upstream tasks to succeed.
+    This would need to be generalized.
+    """
+    uuid = context.get("task_instance").xcom_pull(key="uuid")
+    crypt_auth_tok = context.get("crypt_auth_tok")
+    auth_tok = get_auth_tok(**{"crypt_auth_tok": crypt_auth_tok})
+    endpoint = f"/entities/{uuid}"
+    headers = {
+        "authorization": "Bearer " + auth_tok,
+        "X-Hubmap-Application": "ingest-pipeline",
+        "content-type": "application/json",
+    }
+    extra_options = []
+    http_conn_id = "entity_api_connection"
+    http_hook = HttpHook("PUT", http_conn_id=http_conn_id)
+    data = {"status": "Invalid", "validation_message": formatted_exception}
+    print("data: ")
+    pprint(data)
+    response = http_hook.run(
+        endpoint,
+        json.dumps(data),
+        headers,
+        extra_options,
     )
 
-sys.path.append(airflow_conf.as_dict()['connections']['SRC_PATH']
-                .strip("'").strip('"'))
-from submodules import (ingest_validation_tools_upload,  # noqa E402
-                        ingest_validation_tools_error_report,
-                        ingest_validation_tests)
-sys.path.pop()
 
 # Following are defaults which can be overridden later on
 default_args = {
-    'owner': 'hubmap',
-    'depends_on_past': False,
-    'start_date': datetime(2019, 1, 1),
-    'email': ['joel.welling@gmail.com'],
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=1),
-    'xcom_push': True,
-    'queue': get_queue_resource('validate_upload')
+    "owner": "hubmap",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 1, 1),
+    "email": ["gesina@psc.edu"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "on_failure_callback": failure_email_function,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+    "xcom_push": True,
+    "queue": get_queue_resource("validate_upload"),
 }
 
-with HMDAG('validate_upload',
-           schedule_interval=None,
-           is_paused_upon_creation=False,
-           default_args=default_args,
-           user_defined_macros={
-               'tmp_dir_path': get_tmp_dir_path,
-               'preserve_scratch': get_preserve_scratch_resource('validate_upload'),
-           }) as dag:
+with HMDAG(
+    "validate_upload",
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+    default_args=default_args,
+    user_defined_macros={
+        "tmp_dir_path": get_tmp_dir_path,
+        "preserve_scratch": get_preserve_scratch_resource("validate_upload"),
+    },
+) as dag:
 
     def find_uuid(**kwargs):
-        uuid = kwargs['dag_run'].conf['uuid']
+        uuid = kwargs["dag_run"].conf["uuid"]
 
         def my_callable(**kwargs):
             return uuid
 
-        ds_rslt = pythonop_get_dataset_state(
-            dataset_uuid_callable=my_callable,
-            **kwargs
-        )
+        ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=my_callable, **kwargs)
         if not ds_rslt:
-            raise AirflowException(f'Invalid uuid/doi for group: {uuid}')
-        print('ds_rslt:')
+            raise AirflowException(f"Invalid uuid/doi for group: {uuid}")
+        print("ds_rslt:")
         pprint(ds_rslt)
 
-        for key in ['entity_type', 'status', 'uuid', 'data_types',
-                    'local_directory_full_path']:
+        for key in ["entity_type", "status", "uuid", "data_types", "local_directory_full_path"]:
             assert key in ds_rslt, f"Dataset status for {uuid} has no {key}"
 
-        if ds_rslt['entity_type'] != 'Upload':
-            raise AirflowException(f'{uuid} is not an Upload')
-        if ds_rslt['status'] not in ['New', 'Submitted', 'Invalid', 'Processing']:
-            raise AirflowException(f'status of Upload {uuid} is not New, Submitted, Invalid, or Processing')
+        if ds_rslt["entity_type"] != "Upload":
+            raise AirflowException(f"{uuid} is not an Upload")
+        if ds_rslt["status"] not in ["New", "Submitted", "Invalid", "Processing"]:
+            raise AirflowException(
+                f"status of Upload {uuid} is not New, Submitted, Invalid, or Processing"
+            )
 
-        lz_path = ds_rslt['local_directory_full_path']
-        uuid = ds_rslt['uuid']  # 'uuid' may  actually be a DOI
-        print(f'Finished uuid {uuid}')
-        print(f'lz path: {lz_path}')
-        kwargs['ti'].xcom_push(key='lz_path', value=lz_path)
-        kwargs['ti'].xcom_push(key='uuid', value=uuid)
+        lz_path = ds_rslt["local_directory_full_path"]
+        uuid = ds_rslt["uuid"]  # 'uuid' may  actually be a DOI
+        print(f"Finished uuid {uuid}")
+        print(f"lz path: {lz_path}")
+        kwargs["ti"].xcom_push(key="lz_path", value=lz_path)
+        kwargs["ti"].xcom_push(key="uuid", value=uuid)
 
     t_find_uuid = PythonOperator(
-        task_id='find_uuid',
+        task_id="find_uuid",
         python_callable=find_uuid,
         provide_context=True,
         op_kwargs={
-            }
-        )
+            "crypt_auth_tok": (
+                encrypt_tok(airflow_conf.as_dict()["connections"]["APP_CLIENT_SECRET"]).decode()
+            )
+        },
+    )
 
     def run_validation(**kwargs):
-        lz_path = kwargs['ti'].xcom_pull(key='lz_path')
-        uuid = kwargs['ti'].xcom_pull(key='uuid')
+        # Force an error to test email
+        # raise Exception("test")
+        lz_path = kwargs["ti"].xcom_pull(key="lz_path")
+        uuid = kwargs["ti"].xcom_pull(key="uuid")
         plugin_path = [path for path in ingest_validation_tests.__path__][0]
 
-        ignore_globs = [uuid, 'extras', '*metadata.tsv',
-                        'validation_report.txt']
+        ignore_globs = [uuid, "extras", "*metadata.tsv", "validation_report.txt"]
         #
         # Uncomment offline=True below to avoid validating orcid_id URLs &etc
         #
         upload = ingest_validation_tools_upload.Upload(
             directory_path=Path(lz_path),
             dataset_ignore_globs=ignore_globs,
-            upload_ignore_globs='*',
+            upload_ignore_globs="*",
             plugin_directory=plugin_path,
             # offline=True,  # noqa E265
             add_notes=False,
-            extra_parameters={'coreuse': get_threads_resource('validate_upload', 'run_validation')}
+            extra_parameters={
+                "coreuse": get_threads_resource("validate_upload", "run_validation")
+            },
         )
         # Scan reports an error result
         report = ingest_validation_tools_error_report.ErrorReport(
-            errors=upload.get_errors(plugin_kwargs=kwargs),
-            info=upload.get_info()
+            errors=upload.get_errors(plugin_kwargs=kwargs), info=upload.get_info()
         )
-        validation_file_path = Path(get_tmp_dir_path(kwargs['run_id'])) / 'validation_report.txt'
-        with open(validation_file_path, 'w') as f:
+        validation_file_path = Path(get_tmp_dir_path(kwargs["run_id"])) / "validation_report.txt"
+        with open(validation_file_path, "w") as f:
             f.write(report.as_text())
-        kwargs['ti'].xcom_push(key='validation_file_path', value=str(validation_file_path))
+        kwargs["ti"].xcom_push(key="validation_file_path", value=str(validation_file_path))
 
     t_run_validation = PythonOperator(
-        task_id='run_validation',
+        task_id="run_validation",
         python_callable=run_validation,
         provide_context=True,
         op_kwargs={
-        }
+            "crypt_auth_tok": (
+                encrypt_tok(airflow_conf.as_dict()["connections"]["APP_CLIENT_SECRET"]).decode()
+            )
+        },
     )
 
     def send_status_msg(**kwargs):
-        validation_file_path = Path(kwargs['ti'].xcom_pull(key='validation_file_path'))
-        uuid = kwargs['ti'].xcom_pull(key='uuid')
-        endpoint = f'/entities/{uuid}'
+        validation_file_path = Path(kwargs["ti"].xcom_pull(key="validation_file_path"))
+        uuid = kwargs["ti"].xcom_pull(key="uuid")
+        endpoint = f"/entities/{uuid}"
         headers = {
-            'authorization': 'Bearer ' + get_auth_tok(**kwargs),
-            'X-Hubmap-Application': 'ingest-pipeline',
-            'content-type': 'application/json',
+            "authorization": "Bearer " + get_auth_tok(**kwargs),
+            "X-Hubmap-Application": "ingest-pipeline",
+            "content-type": "application/json",
         }
         extra_options = []
-        http_conn_id = 'entity_api_connection'
-        http_hook = HttpHook('PUT', http_conn_id=http_conn_id)
+        http_conn_id = "entity_api_connection"
+        http_hook = HttpHook("PUT", http_conn_id=http_conn_id)
         with open(validation_file_path) as f:
             report_txt = f.read()
-        if report_txt.startswith('No errors!'):
+        if report_txt.startswith("No errors!"):
             data = {
                 "status": "Valid",
-            }       
+            }
         else:
-            data = {
-                "status": "Invalid",
-                "validation_message": report_txt
-            }       
-        print('data: ')
+            data = {"status": "Invalid", "validation_message": report_txt}
+        print("data: ")
         pprint(data)
         response = http_hook.run(
             endpoint,
@@ -161,20 +220,21 @@ with HMDAG('validate_upload',
             headers,
             extra_options,
         )
-        print('response: ')
+        print("response: ")
         pprint(response.json())
 
-
-    
     t_send_status = PythonOperator(
-        task_id='send_status',
+        task_id="send_status",
         python_callable=send_status_msg,
         provide_context=True,
         op_kwargs={
-        }        
+            "crypt_auth_tok": (
+                encrypt_tok(airflow_conf.as_dict()["connections"]["APP_CLIENT_SECRET"]).decode()
+            )
+        },
     )
 
-    t_create_tmpdir = CreateTmpDirOperator(task_id='create_temp_dir')
-    t_cleanup_tmpdir = CleanupTmpDirOperator(task_id='cleanup_temp_dir')
+    t_create_tmpdir = CreateTmpDirOperator(task_id="create_temp_dir")
+    t_cleanup_tmpdir = CleanupTmpDirOperator(task_id="cleanup_temp_dir")
 
     t_create_tmpdir >> t_find_uuid >> t_run_validation >> t_send_status >> t_cleanup_tmpdir

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -37,6 +37,12 @@ from submodules import (
 
 sys.path.pop()
 
+"""
+TODO
+- fix validation message being pushed in failure_email_function
+- identify different types of errors and email creator for subset
+"""
+
 
 def failure_email_function(context):
     # traceback logic borrowed from https://stackoverflow.com/questions/51822029/get-exception-details-on-airflow-on-failure-callback-context

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -157,8 +157,10 @@ with HMDAG(
     )
 
     def run_validation(**kwargs):
-        # Force an error to test email
+        # Force an exception to test internal email
         # raise Exception("test")
+        # Force an exception to test internal and external email
+        # raise ValueError
         lz_path = kwargs["ti"].xcom_pull(key="lz_path")
         uuid = kwargs["ti"].xcom_pull(key="uuid")
         plugin_path = [path for path in ingest_validation_tests.__path__][0]


### PR DESCRIPTION
I'd love feedback on the base class (catch_pipeline_errors.py) and the subclass implementation in validate_upload.py.

Notes:
- The base FailureCallback class can be set as the callback method on a DAG to catch errors in the running DAG and send a notification to the internal email recipients set on the base class (likely data curators). It does not always need to be subclassed.
- However, in order to catch specific errors and send emails to data providers, FailureCallback must be subclassed.
- The ValidateUploadFailure subclass of FailureCallback is necessary in order to send emails when the validate_upload DAG succeeds but sub-processes determine the upload to be Invalid. Without this subclass, no notifications would be sent at all despite the upload entering an invalid state.
- Templates are examples only, the ones in validate_upload.py in particular are not good. Actual templates--in particular those to external users--would need more work.
- There's no reason this couldn't live in utils, I just broke it out into its own file to work on it.

If you want, you can test on dev using this branch. I've been using [this upload](https://ingest.dev.hubmapconsortium.org/upload/207ddcca543e91d6f18293804a89f38f) which has metadata errors. You can turn on one of the test exceptions in validate_upload > run_validation to see how it behaves if the DAG itself fails.