### PR TITLE
Blank validation_message on successful validation

### DIFF
--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -151,9 +151,13 @@ with HMDAG(
         if report_txt.startswith("No errors!"):
             data = {
                 "status": "Valid",
+                "validation_message": "",
             }
         else:
-            data = {"status": "Invalid", "validation_message": report_txt}
+            data = {
+                "status": "Invalid",
+                "validation_message": report_txt,
+            }
             context = kwargs["ti"].get_template_context()
             ValidateUploadFailure(context, execute_methods=False).send_failure_email(
                 report_txt=report_txt

--- a/src/ingest-pipeline/airflow/dags/workflow_map.yml
+++ b/src/ingest-pipeline/airflow/dags/workflow_map.yml
@@ -21,7 +21,7 @@ workflow_map:
     'assay_type': 'cell-dive'
     'workflow': 'celldive_deepcell'
   - 'collection_type': '.*'
-    'assay_type': 'mibi'
+    'assay_type': 'MIBI'
     'workflow': 'mibi_deepcell'
   - 'collection_type': '.*'
     'assay_type': 'MxIF'


### PR DESCRIPTION
Updated flow to clear/blank validation_message after a successful validation which makes the message outdated/useless on the upload/dataset.