### PR TITLE
salmon_rnaseq DAGs: remove --debug from cwltool cmd

### DIFF
--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
@@ -90,7 +90,6 @@ def generate_salmon_rnaseq_dag(params: SequencingDagParameters) -> DAG:
             command = [
                 *get_cwltool_base_cmd(tmpdir),
                 "--relax-path-checks",
-                "--debug",
                 "--outdir",
                 tmpdir / "cwl_out",
                 "--parallel",


### PR DESCRIPTION
This debug output is from the CWL tool runner, not our pipelines or analysis code, and relates to how input/output files are mapped between workflow steps. This information is really only useful when *writing* CWL workflows, not when diagnosing pipeline failures, and dramatically bloat the log file contents, making it more difficult to find useful information about any particular failure.