### PR TITLE
Removing cannonical rename

### DIFF
--- a/src/ingest-pipeline/misc/tools/split_and_create.py
+++ b/src/ingest-pipeline/misc/tools/split_and_create.py
@@ -186,7 +186,7 @@ def populate(row, source_entity, entity_factory, dryrun=False):
         row['antibodies_path'] = str(new_antibodies_path)
     else:
         old_antibodies_path = None
-    row['assay_type'] = row['canonical_assay_type']
+    # row['assay_type'] = row['canonical_assay_type']
     row_df = pd.DataFrame([row])
     row_df = row_df.drop(columns=['canonical_assay_type', 'new_uuid'])
     if dryrun:


### PR DESCRIPTION
Removing cannonical renaming of assay_type on metadata.tsv file to avoid problems in pipelines/validation tools.