### PR TITLE
Indentation error caused gen_pub_ancillary to do the right thing the wrong way

### DIFF
--- a/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
+++ b/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
@@ -188,8 +188,8 @@ with HMDAG(
                     this_vignette_all_paths.remove(md_path)
                     for fig in vig_block['figures']:
                         this_vignette_all_paths.remove(this_vignette_path / fig['file'])
-                    assert not this_vignette_all_paths, ('unexpected files in vignette:'
-                                                         f' {this_vignette_all_paths}')
+                assert not this_vignette_all_paths, ('unexpected files in vignette:'
+                                                     f' {this_vignette_all_paths}')
 
                 rslt['vignettes'].append(vig_block)
 


### PR DESCRIPTION
This PR changes the nesting level of one of the tests performed on publication directories as their ancillary data is built.  I don't think the error actually could cause any good dataset to be rejected or bad dataset to be passed, but it wasn't the intended logic pattern.