### PR TITLE
Add imagecodecs to requirements.txt

### DIFF
--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -42,3 +42,4 @@ numpyencoder==0.3.0
 tqdm==4.36.1
 pandarallel==1.6.4
 python-frontmatter>=1.0.0
+imagecodecs>=2023.3.16


### PR DESCRIPTION
The submodule ingest-validation-tests requires the imagecodecs module now, so add imagecodecs to requirements.txt here.