### PR TITLE
updating .gitignore to be more useful, added flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore=W503
+max-line-length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,26 @@
+*~
+*.pyc
+__pycache__
+.env
+.envrc
 .idea
 .vs
 .vscode
-*.pyc
 db.sqlite3
-*~
-__pycache__
 media/*
 media
 
 docker/dev-local
+
+# airflow/secrets
+.pgpwd
+airflow.cfg
+airflow.db
+pg_celery_conn.sh
+pg_conn.sh
+src/ingest-pipeline/misc/tools/.token.json
+src/ingest-pipeline/airflow/logs/
+src/ingest-pipeline/airflow/instance/app.cfg
 
 # dependencies
 node_modules


### PR DESCRIPTION
- updating .gitignore to be more useful
     - @jpuerto-psc @sunset666 as a note here, I tend to think that we should commit the `airflow/instance` dir with `app.cfg` in .gitignore but `app.cfg.example` committed (assuming it can be updated to be current/helpful--I am happy to take a stab at that)
     - UNLESS there's a way this would interfere with using GitLab to store secrets
- added flake8 config file