### PR TITLE
Bump azimuth-annotate

### DIFF
--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
@@ -127,7 +127,9 @@ def generate_salmon_rnaseq_dag(params: SequencingDagParameters) -> DAG:
                 "--matrix",
                 "expr.h5ad",
                 "--secondary-analysis-matrix",
-                "secondary_analysis.h5ad"
+                "secondary_analysis.h5ad",
+                "--assay",
+                params.assay
             ]
 
             return join_quote_command_str(command)


### PR DESCRIPTION
- Uses [new repo](https://github.com/hubmapconsortium/expr-h5ad-adjust) built by @mruffalo to modify the `expr.h5ad `file so that it uses the same counts for annotating as are included in the `secondary_analysis.h5ad` file
- Added `assay` parameter to the Salmon pipeline for annotation 