### PR TITLE
Bugfix: upload and dataset status update during reorganize

### DIFF
--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -117,11 +117,13 @@ class StatusChanger:
         extras: StatusChangerExtras | None = None,
         entity_type: str | None = None,
         http_conn_id: str = "entity_api_connection",
+        endpoint: str = "",
         verbose: bool = True,
     ):
         self.uuid = uuid
         self.token = token
         self.http_conn_id = http_conn_id
+        self.endpoint = endpoint
         self.verbose = verbose
         self.status = (
             self.check_status(status)
@@ -194,7 +196,10 @@ class StatusChanger:
         return data
 
     def set_entity_api_status(self) -> Dict:
-        endpoint = f"/entities/{self.uuid}"
+        if self.endpoint:
+            endpoint = self.endpoint
+        else:
+            endpoint = f"/entities/{self.uuid}"
         headers = {
             "authorization": "Bearer " + self.token,
             "X-Hubmap-Application": "ingest-pipeline",

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -119,13 +119,11 @@ class StatusChanger:
         extras: StatusChangerExtras | None = None,
         entity_type: str | None = None,
         http_conn_id: str = "entity_api_connection",
-        endpoint: str = "",
         verbose: bool = True,
     ):
         self.uuid = uuid
         self.token = token
         self.http_conn_id = http_conn_id
-        self.endpoint = endpoint
         self.verbose = verbose
         self.status = (
             self.check_status(status)
@@ -198,18 +196,13 @@ class StatusChanger:
         return data
 
     def set_entity_api_status(self) -> Dict:
-        if self.endpoint:
-            endpoint = self.endpoint
-            http_conn_id = ""
-        else:
-            endpoint = f"/entities/{self.uuid}"
-            http_conn_id = self.http_conn_id
+        endpoint = f"/entities/{self.uuid}"
         headers = {
             "authorization": "Bearer " + self.token,
             "X-Hubmap-Application": "ingest-pipeline",
             "content-type": "application/json",
         }
-        http_hook = HttpHook("PUT", http_conn_id=http_conn_id)
+        http_hook = HttpHook("PUT", http_conn_id=self.http_conn_id)
         data = self.format_status_data()
         if self.extras["extra_options"].get("check_response") is None:
             self.extras["extra_options"].update({"check_response": True})

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -21,6 +21,7 @@ class Statuses(str, Enum):
     DATASET_PROCESSING = "processing"
     DATASET_PUBLISHED = "published"
     DATASET_QA = "qa"
+    DATASET_SUBMITTED = "submitted"
     PUBLICATION_ERROR = "error"
     PUBLICATION_HOLD = "hold"
     PUBLICATION_INVALID = "invalid"
@@ -49,6 +50,7 @@ ENTITY_STATUS_MAP = {
         "processing": Statuses.DATASET_PROCESSING,
         "published": Statuses.DATASET_PUBLISHED,
         "qa": Statuses.DATASET_QA,
+        "submitted": Statuses.DATASET_SUBMITTED,
     },
     "publication": {
         "error": Statuses.PUBLICATION_ERROR,
@@ -198,14 +200,16 @@ class StatusChanger:
     def set_entity_api_status(self) -> Dict:
         if self.endpoint:
             endpoint = self.endpoint
+            http_conn_id = ""
         else:
             endpoint = f"/entities/{self.uuid}"
+            http_conn_id = self.http_conn_id
         headers = {
             "authorization": "Bearer " + self.token,
             "X-Hubmap-Application": "ingest-pipeline",
             "content-type": "application/json",
         }
-        http_hook = HttpHook("PUT", http_conn_id=self.http_conn_id)
+        http_hook = HttpHook("PUT", http_conn_id=http_conn_id)
         data = self.format_status_data()
         if self.extras["extra_options"].get("check_response") is None:
             self.extras["extra_options"].update({"check_response": True})

--- a/src/ingest-pipeline/misc/tools/split_and_create.py
+++ b/src/ingest-pipeline/misc/tools/split_and_create.py
@@ -266,11 +266,7 @@ def update_upload_entity(child_uuid_list, source_entity, dryrun=False, verbose=F
         else:
             # Set Upload status to "Reorganized"
             # Set links from Upload to split Datasets
-            entity_url = ENDPOINTS[source_entity.entity_factory.instance]["entity_url"]
-            endpoint = f"{entity_url}/entities/{source_entity.uuid}"
-            print(
-                f"Setting status of {source_entity.uuid} to 'Reorganized' at {endpoint}. Child UUIDs:"
-            )
+            print(f"Setting status of {source_entity.uuid} to 'Reorganized'. Child UUIDs:")
             pprint(child_uuid_list)
             StatusChanger(
                 source_entity.uuid,
@@ -280,20 +276,17 @@ def update_upload_entity(child_uuid_list, source_entity, dryrun=False, verbose=F
                     "extra_fields": {"dataset_uuids_to_link": child_uuid_list},
                     "extra_options": {},
                 },
-                endpoint=endpoint,
                 verbose=verbose,
             ).on_status_change()
             print(f"{source_entity.uuid} status is Reorganized")
 
             # TODO: click in with UpdateAsana
             for uuid in child_uuid_list:
-                endpoint = f"{entity_url}/entities/{uuid}"
-                print(f"sending to {endpoint}: dataset {uuid} status is Submitted")
+                print(f"Setting status of dataset {uuid} to Submitted")
                 StatusChanger(
                     uuid,
                     source_entity.entity_factory.auth_tok,
                     Statuses.DATASET_SUBMITTED,
-                    endpoint=endpoint,
                     verbose=verbose,
                 ).on_status_change()
                 print(


### PR DESCRIPTION
I introduced a bug during the status setting phase of `split_and_create.py > reorganize` and also did not include `DATASET_SUBMITTED` in the list of statuses in `status_manager`.