### PR TITLE
do not need cedar api key arg when instantiating upload

### DIFF
--- a/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
+++ b/src/ingest-pipeline/airflow/dags/scan_and_begin_processing.py
@@ -119,7 +119,6 @@ with HMDAG(
             add_notes=False,
             ignore_deprecation=True,
             globus_token=get_auth_tok(**kwargs),
-            cedar_api_key=airflow_conf.as_dict()["connections"]["CEDAR_API_KEY"],
         )
         # Scan reports an error result
         errors = upload.get_errors(plugin_kwargs=kwargs)

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -111,11 +111,8 @@ with HMDAG(
             plugin_directory=plugin_path,
             # offline=True,  # noqa E265
             add_notes=False,
-            extra_parameters={
-                "coreuse": get_threads_resource("validate_upload", "run_validation")
-            },
+            extra_parameters={"coreuse": get_threads_resource("validate_upload", "run_validation")},
             globus_token=get_auth_tok(**kwargs),
-            cedar_api_key=airflow_conf.as_dict()["connections"]["CEDAR_API_KEY"],
         )
         # Scan reports an error result
         report = ingest_validation_tools_error_report.ErrorReport(


### PR DESCRIPTION
Changed to support ingest-validation-tools