### PR TITLE
Jpuerto/nihdev 456 update pipeline da gs to set the dataset type field for derived datasets appropriately

### DIFF
--- a/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
+++ b/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
@@ -226,6 +226,7 @@ with HMDAG(
         },
     )
 
+    # TODO - Unique scenario for dataset_type
     t_send_create_dataset = PythonOperator(
         task_id="send_create_dataset",
         python_callable=utils.pythonop_send_create_dataset,

--- a/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
+++ b/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
@@ -235,7 +235,7 @@ with HMDAG(
             "previous_revision_uuid_callable": get_previous_revision_uuid,
             "http_conn_id": "ingest_api_connection",
             "dataset_name_callable": get_dataname_previous_version,
-            "dataset_types_callable": get_dataset_type_previous_version,
+            "dataset_type_callable": get_dataset_type_previous_version,
         },
     )
 

--- a/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
+++ b/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
@@ -226,7 +226,6 @@ with HMDAG(
         },
     )
 
-    # TODO - Unique scenario for dataset_type
     t_send_create_dataset = PythonOperator(
         task_id="send_create_dataset",
         python_callable=utils.pythonop_send_create_dataset,

--- a/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
+++ b/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
@@ -28,7 +28,7 @@ from utils import (
     HMDAG,
     get_queue_resource,
     get_preserve_scratch_resource,
-    get_datatype_previous_version,
+    get_dataset_type_previous_version,
     get_dataname_previous_version,
     build_provenance_function,
     get_assay_previous_version,
@@ -236,7 +236,7 @@ with HMDAG(
             "previous_revision_uuid_callable": get_previous_revision_uuid,
             "http_conn_id": "ingest_api_connection",
             "dataset_name_callable": get_dataname_previous_version,
-            "dataset_types_callable": get_datatype_previous_version,
+            "dataset_types_callable": get_dataset_type_previous_version,
         },
     )
 

--- a/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_atacseq.py
@@ -122,7 +122,7 @@ with HMDAG('bulk_atacseq',
             'previous_revision_uuid_callable': get_previous_revision_uuid,
             'http_conn_id': 'ingest_api_connection',
             'dataset_name_callable': build_dataset_name,
-            'dataset_types': ['bulk_atacseq'],
+            'pipeline_shorthand': 'BWA + MACS2',
         },
     )
 

--- a/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
@@ -427,7 +427,7 @@ with HMDAG('celldive_deepcell',
             'previous_revision_uuid_callable': get_previous_revision_uuid,
             'http_conn_id': 'ingest_api_connection',
             'dataset_name_callable': build_dataset_name,
-            'dataset_types': ['celldive_deepcell'],
+            'pipeline_shorthand': 'DeepCell + SPRM',
         },
     )
 

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -528,7 +528,7 @@ with HMDAG('codex_cytokit',
                    'previous_revision_uuid_callable': get_previous_revision_uuid,
                    'http_conn_id': 'ingest_api_connection',
                    'dataset_name_callable': build_dataset_name,
-                   'dataset_types': ['codex_cytokit']
+                   'pipeline_shorthand': 'Cytokit + SPRM'
                    }
     )
 

--- a/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
+++ b/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
@@ -233,7 +233,7 @@ with HMDAG(
                    'previous_revision_uuid_callable': get_previous_revision_uuid,
                    'http_conn_id': 'ingest_api_connection',
                    'dataset_name_callable': build_dataset_name,
-                   'dataset_types': ["publication_ancillary"]
+                   'pipeline_shorthand': 'ancillary'
                    }
     )
 

--- a/src/ingest-pipeline/airflow/dags/mibi_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/mibi_deepcell.py
@@ -426,7 +426,7 @@ with HMDAG('mibi_deepcell',
             'previous_revision_uuid_callable': get_previous_revision_uuid,
             'http_conn_id': 'ingest_api_connection',
             'dataset_name_callable': build_dataset_name,
-            'dataset_types': ['mibi_deepcell'],
+            'pipeline_shorthand': 'DeepCell + SPRM'
         },
     )
 

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -175,7 +175,7 @@ with HMDAG('ometiff_pyramid',
                    'previous_revision_uuid_callable': get_previous_revision_uuid,
                    'http_conn_id': 'ingest_api_connection',
                    'dataset_name_callable': build_dataset_name,
-                   'dataset_types': ["image_pyramid"]
+                    'pipeline_shorthand': 'Image Pyramid'
                    }
     )
 

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -181,7 +181,7 @@ with HMDAG('ometiff_pyramid_ims',
                    'previous_revision_uuid_callable': get_previous_revision_uuid,
                    'http_conn_id': 'ingest_api_connection',
                    'dataset_name_callable': build_dataset_name,
-                   'dataset_types': ["image_pyramid"]
+                    'pipeline_shorthand': 'Image Pyramid'
                    }
     )
 

--- a/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
+++ b/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
@@ -226,6 +226,7 @@ with HMDAG(
         },
     )
 
+    # TODO - Unique scenario for dataset_type
     t_send_create_dataset = PythonOperator(
         task_id="send_create_dataset",
         python_callable=utils.pythonop_send_create_dataset,

--- a/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
+++ b/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
@@ -22,7 +22,7 @@ from utils import (
     get_queue_resource,
     get_preserve_scratch_resource,
     pythonop_get_dataset_state,
-    get_datatype_organ_based,
+    get_dataset_type_organ_based,
 )
 from hubmap_operators.common_operators import (
     CleanupTmpDirOperator,
@@ -226,7 +226,6 @@ with HMDAG(
         },
     )
 
-    # TODO - Unique scenario for dataset_type
     t_send_create_dataset = PythonOperator(
         task_id="send_create_dataset",
         python_callable=utils.pythonop_send_create_dataset,
@@ -236,7 +235,7 @@ with HMDAG(
             "previous_revision_uuid_callable": get_previous_revision_uuid,
             "http_conn_id": "ingest_api_connection",
             "dataset_name_callable": build_dataset_name,
-            "dataset_types_callable": get_datatype_organ_based,
+            "dataset_types_callable": get_dataset_type_organ_based,
         },
     )
 

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
@@ -372,7 +372,7 @@ def get_salmon_dag_params(assay: str) -> SequencingDagParameters:
         dataset_type=f"salmon_rnaseq_{assay}",
     )
 
-
+# TODO: Unique scenario for dataset_type
 salmon_dag_params: List[SequencingDagParameters] = [
     # 10X is special because it was first; no "10x" label in the pipeline name
     SequencingDagParameters(

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
@@ -288,7 +288,7 @@ def generate_salmon_rnaseq_dag(params: SequencingDagParameters) -> DAG:
                 "previous_revision_uuid_callable": get_previous_revision_uuid,
                 "http_conn_id": "ingest_api_connection",
                 "dataset_name_callable": build_dataset_name,
-                "dataset_types": [params.dataset_type],
+                "pipeline_shorthand": "Salmon"
             },
         )
 
@@ -369,35 +369,29 @@ def get_salmon_dag_params(assay: str) -> SequencingDagParameters:
         dag_id=f"salmon_rnaseq_{assay}",
         pipeline_name=f"salmon-rnaseq-{assay}",
         assay=assay,
-        dataset_type=f"salmon_rnaseq_{assay}",
     )
 
-# TODO: Unique scenario for dataset_type
 salmon_dag_params: List[SequencingDagParameters] = [
     # 10X is special because it was first; no "10x" label in the pipeline name
     SequencingDagParameters(
         dag_id="salmon_rnaseq_10x",
         pipeline_name="salmon-rnaseq",
         assay="10x_v3",
-        dataset_type="salmon_rnaseq_10x",
     ),
     SequencingDagParameters(
         dag_id="salmon_rnaseq_10x_sn",
         pipeline_name="salmon-rnaseq",
         assay="10x_v3_sn",
-        dataset_type="salmon_sn_rnaseq_10x",
     ),
     SequencingDagParameters(
         dag_id="salmon_rnaseq_10x_v2",
         pipeline_name="salmon-rnaseq",
         assay="10x_v2",
-        dataset_type="salmon_rnaseq_10x",
     ),
     SequencingDagParameters(
         dag_id="salmon_rnaseq_10x_v2_sn",
         pipeline_name="salmon-rnaseq",
         assay="10x_v2_sn",
-        dataset_type="salmon_sn_rnaseq_10x",
     ),
     get_salmon_dag_params("sciseq"),
     get_salmon_dag_params("slideseq"),

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
@@ -119,7 +119,7 @@ with HMDAG('salmon_rnaseq_bulk',
             'http_conn_id': 'ingest_api_connection',
             'previous_revision_uuid_callable': get_previous_revision_uuid,
             'dataset_name_callable': build_dataset_name,
-            "dataset_types": ["salmon_rnaseq_bulk"],
+            'pipeline_shorthand': 'Salmon'
         },
     )
 

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
@@ -233,7 +233,7 @@ def generate_atac_seq_dag(params: SequencingDagParameters) -> DAG:
 
     return dag
 
-
+# TODO: Unique scenario for dataset_type
 atacseq_dag_data: List[SequencingDagParameters] = [
     SequencingDagParameters(
         dag_id="sc_atac_seq_sci",

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
@@ -174,7 +174,7 @@ def generate_atac_seq_dag(params: SequencingDagParameters) -> DAG:
                 "previous_revision_uuid_callable": get_previous_revision_uuid,
                 "http_conn_id": "ingest_api_connection",
                 "dataset_name_callable": build_dataset_name,
-                "dataset_types": [params.dataset_type],
+                "pipeline_shorthand": "SnapATAC"
             },
         )
 
@@ -233,31 +233,26 @@ def generate_atac_seq_dag(params: SequencingDagParameters) -> DAG:
 
     return dag
 
-# TODO: Unique scenario for dataset_type
 atacseq_dag_data: List[SequencingDagParameters] = [
     SequencingDagParameters(
         dag_id="sc_atac_seq_sci",
         pipeline_name="sci-atac-seq-pipeline",
         assay="sciseq",
-        dataset_type="sc_atac_seq_sci",
     ),
     SequencingDagParameters(
         dag_id="sc_atac_seq_snare",
         pipeline_name="sc-atac-seq-pipeline",
         assay="snareseq",
-        dataset_type="sc_atac_seq_snare",
     ),
     SequencingDagParameters(
         dag_id="sc_atac_seq_sn",
         pipeline_name="sn-atac-seq-pipeline",
         assay="snseq",
-        dataset_type="sn_atac_seq",
     ),
     SequencingDagParameters(
         dag_id="sc_atac_seq_multiome_10x",
         pipeline_name="sn-atac-seq-pipeline",
         assay="multiome_10x",
-        dataset_type="sn_atac_seq_multiome_10x",
     ),
 ]
 

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -129,7 +129,6 @@ SequencingDagParameters = namedtuple(
         "dag_id",
         "pipeline_name",
         "assay",
-        "dataset_type",
     ],
 )
 

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -321,7 +321,7 @@ def get_datatype_organ_based(**kwargs) -> List[str]:
     return ["image_pyramid"]
 
 
-def get_datatype_previous_version(**kwargs) -> List[str]:
+def get_dataset_type_previous_version(**kwargs) -> List[str]:
     dataset_uuid = get_previous_revision_uuid(**kwargs)
     assert dataset_uuid is not None, "Missing previous_version_uuid"
 
@@ -329,7 +329,7 @@ def get_datatype_previous_version(**kwargs) -> List[str]:
         return dataset_uuid
 
     ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=my_callable, **kwargs)
-    return ds_rslt["data_types"]
+    return ds_rslt["dataset_type"]
 
 
 def get_dataname_previous_version(**kwargs) -> str:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -720,7 +720,7 @@ def pythonop_send_create_dataset(**kwargs) -> str:
                              between the brackets in the dataset_type
     or
       'dataset_type_callable' : called with **kwargs; returns the
-                                 types list of the new dataset
+                                 dataset_type of the new dataset
 
     Returns the following via XCOM:
     (no key) : data_directory_path for the new dataset

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -307,7 +307,7 @@ def get_parent_dataset_uuid(**kwargs) -> str:
     return uuid_set.pop()
 
 
-def get_datatype_organ_based(**kwargs) -> List[str]:
+def get_dataset_type_organ_based(**kwargs) -> str:
     dataset_uuid = get_parent_dataset_uuid(**kwargs)
 
     def my_callable(**kwargs):
@@ -316,9 +316,9 @@ def get_datatype_organ_based(**kwargs) -> List[str]:
     ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=my_callable, **kwargs)
     organ_list = list(set(ds_rslt["organs"]))
     organ_code = organ_list[0] if len(organ_list) == 1 else "multi"
-    if organ_code in ["LK", "RK"]:
-        return ["pas_ftu_segmentation"]
-    return ["image_pyramid"]
+    pipeline_shorthand = "Kaggle-1 Glomerulus Segmentation" if organ_code in ["LK", "RK"] else "Image Pyramid"
+
+    return f"{ds_rslt['dataset_type']} [{pipeline_shorthand}]"
 
 
 def get_dataset_type_previous_version(**kwargs) -> List[str]:
@@ -720,7 +720,7 @@ def pythonop_send_create_dataset(**kwargs) -> str:
       'pipeline_shorthand' : the descriptor for the pipeline that goes
                              between the brackets in the dataset_type
     or
-      'dataset_types_callable' : called with **kwargs; returns the
+      'dataset_type_callable' : called with **kwargs; returns the
                                  types list of the new dataset
 
     Returns the following via XCOM:


### PR DESCRIPTION
These changes are to support the new dataset_type field for processed datasets.

Values chosen for `pipeline_shorthand` come from this Cypher query written by Bill to backfill old data:
https://github.com/hubmapconsortium/manual-data-ingest/issues/268