### PR TITLE
Adding log and new header

### DIFF
--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -218,6 +218,7 @@ class StatusChanger:
             response = http_hook.run(
                 endpoint, json.dumps(data), headers, self.extras["extra_options"]
             )
+            logging.info(f"""Response: {response.json()}""")
             return response.json()
         except Exception as e:
             raise StatusChangerException(

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -941,6 +941,7 @@ def pythonop_get_dataset_state(**kwargs) -> Dict:
     headers = {
         "authorization": f"Bearer {auth_tok}",
         "content-type": "application/json",
+        "Cache-Control": "no-cache",
         "X-Hubmap-Application": "ingest-pipeline",
     }
     http_hook = HttpHook(method, http_conn_id="entity_api_connection")


### PR DESCRIPTION
Adding header to the get_dataset_state function requesting no-cache and adding response information from entity-api to the logs to debug missing updates on status.