### PR TITLE
StatusChanger update to allow appending to existing metadata in Entity API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__
 .vs
 .vscode
 db.sqlite3
+daily-report
+data
+.datasets
 media/*
 media
 .envrc
@@ -17,6 +20,8 @@ docker/dev-local
 .pgpwd
 airflow.cfg
 airflow.db
+airflow_exe
+airflow-worker.pid
 pg_celery_conn.sh
 pg_conn.sh
 src/ingest-pipeline/misc/tools/.token.json

--- a/src/ingest-pipeline/airflow/dags/status_change/failure_callback.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/failure_callback.py
@@ -58,9 +58,6 @@ class FailureCallback:
         StatusChanger(
             self.uuid,
             self.auth_tok,
-            "error",
-            {
-                "extra_fields": self.get_extra_fields(),
-                "extra_options": {},
-            },
-        ).on_status_change()
+            status="error",
+            fields_to_overwrite=data,
+        ).update()

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -117,7 +117,9 @@ class EntityUpdater:
         status_found = False
         for field in self.fields_to_change.keys():
             if field not in self.entity_data.keys():
-                raise Exception(f"Field {field} is invalid for entity type {self.entity_type}.")
+                raise EntityUpdateException(
+                    f"Field {field} is invalid for entity type {self.entity_type}."
+                )
             elif field == "status":
                 status_found = True
         if status_found:
@@ -194,7 +196,7 @@ class StatusChanger:
         self.extra_options = extra_options if extra_options else {}
         self.verbose = verbose
         if not status:
-            raise Exception("Must pass new status to StatusChanger.")
+            raise EntityUpdateException("Must pass new status to StatusChanger.")
         self.entity_type = entity_type if entity_type else self.get_entity_type()
         self.status = (
             self._check_status(status)
@@ -251,7 +253,9 @@ class StatusChanger:
         # TODO: this does basic key checking but should it also try to check value type?
         for field in self.fields_to_change.keys():
             if field not in self.entity_data.keys():
-                raise Exception(f"Field {field} is invalid for entity type {self.entity_type}.")
+                raise EntityUpdateException(
+                    f"Field {field} is invalid for entity type {self.entity_type}."
+                )
         self.fields_to_change["status"] = self.status
 
     def _get_status(self, status: str) -> Optional[Statuses]:
@@ -264,7 +268,7 @@ class StatusChanger:
         try:
             entity_status = ENTITY_STATUS_MAP[self.entity_type.lower()][status]
         except KeyError:
-            raise Exception(
+            raise EntityUpdateException(
                 f"""
                     Could not retrieve status for {self.uuid}.
                     Check that status is valid for entity type.
@@ -275,7 +279,7 @@ class StatusChanger:
 
     def _check_status(self, status: Statuses) -> Optional[Statuses]:
         if not status:
-            raise Exception(
+            raise EntityUpdateException(
                 "No status passed to StatusChanger. To update other fields only, use EntityUpdater."
             )
         # Can't set the same status over the existing status.
@@ -307,7 +311,7 @@ class StatusChanger:
             assert entity_type is not None
             return entity_type
         except Exception as e:
-            raise Exception(
+            raise EntityUpdateException(
                 f"""
                 Could not find entity type for {self.uuid}.
                 Error {e}
@@ -350,7 +354,7 @@ class StatusChanger:
                 endpoint, json.dumps(self.fields_to_change), headers, self.extra_options
             )
         except Exception as e:
-            raise Exception(
+            raise EntityUpdateException(
                 f"""
                 Encountered error with request to change fields {', '.join([key for key in self.fields_to_change])}
                 for {self.uuid}, fields (likely) not changed.

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -4,11 +4,11 @@ import json
 import logging
 from enum import Enum
 from functools import cached_property
-from typing import Any, Dict, TypedDict, Union
+from typing import Any, Literal, Optional, TypedDict
+
+from status_utils import get_submission_context
 
 from airflow.providers.http.hooks.http import HttpHook
-
-from .status_utils import get_submission_context
 
 
 class Statuses(str, Enum):
@@ -83,84 +83,237 @@ class StatusChangerException(Exception):
     pass
 
 
+class EntityApiUpdater:
+    def __init__(
+        self,
+        uuid: str,
+        token: str,
+        http_conn_id: str = "entity_api_connection",
+        fields_to_overwrite: Optional[dict] = None,
+        fields_to_append_to: Optional[dict] = None,
+        delimiter: str = "|",
+        extra_options: Optional[dict] = None,
+        verbose: bool = True,
+    ):
+        self.uuid = uuid
+        self.token = token
+        self.http_conn_id = http_conn_id
+        self.fields_to_overwrite = fields_to_overwrite if fields_to_overwrite else {}
+        self.fields_to_append_to = fields_to_append_to if fields_to_append_to else {}
+        self.delimiter = delimiter
+        self.extra_options = extra_options if extra_options else {}
+        self.verbose = verbose
+        self.entity_type = self.get_entity_type()
+
+    @cached_property
+    def entity_data(self):
+        return get_submission_context(self.token, self.uuid)
+
+    def get_entity_type(self):
+        try:
+            entity_type = self.entity_data["entity_type"]
+            assert entity_type is not None
+            return entity_type
+        except Exception as e:
+            raise StatusChangerException(
+                f"""
+                Could not find entity type for {self.uuid}.
+                Error {e}
+                """
+            )
+
+    @cached_property
+    def fields_to_change(self) -> dict:
+        # TODO: check directionality on this
+        duplicates = set(self.fields_to_overwrite.keys()).intersection(
+            set(self.fields_to_append_to.keys())
+        )
+        assert (
+            not duplicates
+        ), f"Field(s) {', '.join(duplicates)} cannot be both appended to and overwritten."
+        return self._update_existing_values() | self.fields_to_overwrite
+
+    def update(self):
+        """
+        This is the main method for using the EntityApiUpdater.
+        - Appends values of fields_to_append_to to existing entity-api fields.
+        - Compiles fields to change: fields_to_overwrite + appended fields,
+          ensuring there are no duplicates.
+        - Validates existence of fields_to_change against fields in entity-api data.
+        - If send_to_status_changer and "status" is found in fields_to_change,
+          creates a StatusChanger instance and passes validated data.
+        - Otherwise, makes a PUT request with fields_to_change payload to entity-api.
+        - Returns response.json() or raises Exception.
+        """
+        self._validate_fields_to_change()
+        self._set_entity_api_data()
+
+    def _set_entity_api_data(self) -> dict:
+        endpoint = f"/entities/{self.uuid}"
+        headers = {
+            "authorization": "Bearer " + self.token,
+            "X-Hubmap-Application": "ingest-pipeline",
+            "content-type": "application/json",
+        }
+        http_hook = HttpHook("PUT", http_conn_id=self.http_conn_id)
+        if self.extra_options.get("check_response") is None:
+            self.extra_options.update({"check_response": True})
+        logging.info(
+            f"""
+            data:
+            {self.fields_to_change}
+            """
+        )
+        if self.verbose:
+            logging.info(f"Updating {self.uuid} with data {self.fields_to_change}...")
+        try:
+            response = http_hook.run(
+                endpoint, json.dumps(self.fields_to_change), headers, self.extra_options
+            )
+        except Exception as e:
+            raise StatusChangerException(
+                f"""
+                Encountered error with request to change fields {', '.join([key for key in self.fields_to_change])}
+                for {self.uuid}, fields (likely) not changed.
+                Error: {e}
+                """
+            )
+        logging.info(f"""Response: {response.json()}""")
+        return response.json()
+
+    def _validate_fields_to_change(self):
+        # TODO: this does basic key checking but should it also try to check value type?
+        status_found = False
+        for field in self.fields_to_change.keys():
+            if not field in self.entity_data.keys():
+                raise Exception(f"Field {field} is invalid for entity type {self.entity_type}.")
+            elif field == "status":
+                status_found = True
+        if status_found:
+            logging.info("'status' found in update fields, sending to StatusChanger.")
+            StatusChanger(
+                self.uuid,
+                self.token,
+                self.http_conn_id,
+                self.fields_to_overwrite,
+                self.fields_to_append_to,
+                self.delimiter,
+                self.extra_options,
+                self.verbose,
+                self.fields_to_change["status"],
+                self.entity_type,
+            ).update()
+
+    def _update_existing_values(self):
+        # TODO: appropriate append formatting? only certain fields allowed?
+        new_field_data = {}
+        for field, value in self.fields_to_append_to.items():
+            existing_field_data = self.entity_data[field]
+            new_field_data[field] = existing_field_data + f" {self.delimiter} " + value
+        return new_field_data
+
+
 """
 Example usage, simple path (e.g. status string, no validation message):
     from status_manager import StatusChanger
     StatusChanger(
             "uuid_string",
             "token_string",
-            "status",
-        ).on_status_change()
+            status="status",
+        ).update()
 
-Example usage, optional params path:
+Example usage with some optional params:
     from status_manager import StatusChanger, Statuses
     StatusChanger(
             "uuid_string",
             "token_string",
-            Statuses.STATUS_ENUM or "status",
-            # optional {
-                "extra_fields": {},
-                "extra_options": {},
-            },
-            #optional entity_type="Dataset"|"Upload"|"Publication"
-            #optional http_conn_id="entity_api_connection"
-        ).on_status_change()
+            http_conn_id="entity_api_connection",  # optional
+            fields_to_overwrite={"test_field": "test"},  # optional
+            fields_to_append_to={"ingest_task": "test"},  # optional
+            delimiter=",",  # optional
+            extra_options={},  # optional
+            verbose=True,  # optional
+            status=Statuses.STATUS_ENUM,  # or "<status>"
+            entity_type="Dataset"|"Upload"|"Publication"  # optional
+        ).update()
 """
 
 
-class StatusChanger:
+class StatusChanger(EntityApiUpdater):
     def __init__(
         self,
         uuid: str,
         token: str,
-        # NOTE: status is currently required; should it be possible
-        # to add extra info without updating status?
-        status: Statuses | str,
-        extras: StatusChangerExtras | None = None,
-        entity_type: str | None = None,
         http_conn_id: str = "entity_api_connection",
+        fields_to_overwrite: Optional[dict] = None,
+        fields_to_append_to: Optional[dict] = None,
+        delimiter: str = "|",
+        extra_options: Optional[dict] = None,
         verbose: bool = True,
+        # Additional fields added to support privileged field "status"
+        status: Optional[Statuses | str] = None,
+        entity_type: Optional[Literal["Dataset", "Upload", "Publication"]] = None,
     ):
         self.uuid = uuid
         self.token = token
         self.http_conn_id = http_conn_id
+        self.fields_to_overwrite = fields_to_overwrite if fields_to_overwrite else {}
+        self.fields_to_append_to = fields_to_append_to if fields_to_append_to else {}
+        self.delimiter = delimiter
+        self.extra_options = extra_options if extra_options else {}
         self.verbose = verbose
+        if not status:
+            raise Exception("Must pass new status to StatusChanger.")
+        self.entity_type = entity_type if entity_type else self.get_entity_type()
         self.status = (
-            self.check_status(status)
+            self._check_status(status)
             if isinstance(status, Statuses)
-            else self.get_status(status, entity_type)
-        )
-        self.extras = (
-            extras
-            if extras
-            else {
-                "extra_fields": {},
-                "extra_options": {},
-            }
+            else self._get_status(status.lower())
         )
 
-    def get_status(self, status: str, entity_type: str | None) -> Union[Statuses, None]:
+    status_map = {}
+    """
+    Add any statuses to map that require a specific set of methods.
+    Example:
+    {
+        # "Statuses.UPLOAD_INVALID": [_set_entity_api_status, send_email],
+        # "Statuses.DATASET_INVALID": [_set_entity_api_status, send_email],
+        # "Statuses.DATASET_PROCESSING": [_set_entity_api_status],
+    }
+    """
+
+    def update(self) -> None:
+        """
+        This is the main method for using the StatusChanger.
+        Validates fields to change, adds status that was validated in __init__.
+        If a status was passed in and the status_map is populated:
+            - Run methods assigned to that status in the status_map.
+        Otherwise:
+            - Follows default EntityApiUpdater._set_entity_api_data() process.
+        """
+        self._validate_fields_to_change()
+        if self.status in self.status_map:
+            for func in self.status_map[self.status]:
+                func()
+        else:
+            self._set_entity_api_data()
+
+    def _validate_fields_to_change(self):
+        # TODO: this does basic key checking but should it also try to check value type?
+        for field in self.fields_to_change.keys():
+            if not field in self.entity_data.keys():
+                raise Exception(f"Field {field} is invalid for entity type {self.entity_type}.")
+        self.fields_to_change["status"] = self.status
+
+    def _get_status(self, status: str) -> Optional[Statuses]:
         """
         If status is passed as a string, get the entity type and match
-        to correct entry in ENTITY_STATUS_MAP. Also check current status,
-        because ingest-pipeline will error if you try to set the same status
-        over the existing status.
+        to correct entry in ENTITY_STATUS_MAP.
         Potential TODO: could stop any operation involving "Published"
         statuses at this stage.
         """
-        if entity_type is None:
-            try:
-                entity_type = self.entity_data["entity_type"]
-                assert entity_type is not None
-            except Exception as e:
-                raise StatusChangerException(
-                    f"""
-                    Could not find entity type for {self.uuid}.
-                    Error {e}
-                    """
-                )
         try:
-            entity_status = ENTITY_STATUS_MAP[entity_type.lower()][status.lower()]
+            entity_status = ENTITY_STATUS_MAP[self.entity_type.lower()][status]
         except KeyError:
             raise StatusChangerException(
                 f"""
@@ -169,92 +322,25 @@ class StatusChanger:
                     Status not changed.
                 """
             )
-        return self.check_status(entity_status)
+        return self._check_status(entity_status)
 
-    @cached_property
-    def entity_data(self):
-        return get_submission_context(self.token, self.uuid)
-
-    def check_status(self, status: Statuses) -> Union[Statuses, None]:
+    def _check_status(self, status: Statuses) -> Optional[Statuses]:
+        if not status:
+            raise Exception(
+                f"No status passed to StatusChanger. To update other fields only, use EntityApiUpdater."
+            )
+        # Can't set the same status over the existing status.
         if status == self.entity_data["status"].lower():
             return None
-        return status
-
-    def format_status_data(self) -> Dict[str, str | Dict]:
-        data = {}
-        if self.status:
-            data["status"] = self.status
-        # Double-check that you're not accidentally overwriting status
-        if (extra_status := self.extras.get("status")) is not None and isinstance(
+        # Double-check that you don't have different values for status in other fields.
+        if (extra_status := self.fields_to_change.get("status")) is not None and isinstance(
             extra_status, str
         ):
             assert (
                 extra_status.lower() == self.status
             ), f"Entity {self.uuid} passed multiple statuses ({self.status} and {extra_status})."
-        data.update(self.extras["extra_fields"])
-        logging.info(f"COMPILED DATA: {data}")
-        return data
-
-    def set_entity_api_status(self) -> Dict:
-        endpoint = f"/entities/{self.uuid}"
-        headers = {
-            "authorization": "Bearer " + self.token,
-            "X-Hubmap-Application": "ingest-pipeline",
-            "content-type": "application/json",
-        }
-        http_hook = HttpHook("PUT", http_conn_id=self.http_conn_id)
-        data = self.format_status_data()
-        if self.extras["extra_options"].get("check_response") is None:
-            self.extras["extra_options"].update({"check_response": True})
-        logging.info(
-            f"""
-            data:
-            {data}
-            """
-        )
-        try:
-            if self.verbose:
-                logging.info(f"Updating {self.uuid} with data {data}...")
-            response = http_hook.run(
-                endpoint, json.dumps(data), headers, self.extras["extra_options"]
-            )
-            logging.info(f"""Response: {response.json()}""")
-            return response.json()
-        except Exception as e:
-            raise StatusChangerException(
-                f"""
-                Encountered error with request to change status/fields
-                for {self.uuid}, status not set.
-                Error: {e}
-                """
-            )
-
-    def update_asana(self) -> None:
-        # Separating logic for updating Asana into a separate PR
-        # UpdateAsana(self.uuid, self.token, self.status).update_process_stage()
-        pass
+        return status
 
     def send_email(self) -> None:
         # This is underdeveloped and also requires a separate PR
         pass
-
-    status_map = {}
-    """
-    Default behavior is to call both set_entity_api_status and update_asana.
-    Add any statuses to map that require a different process.
-    Example:
-    {
-        # "Statuses.UPLOAD_INVALID": [set_entity_api_status, update_asana, send_email],
-        # "Statuses.DATASET_INVALID": [set_entity_api_status, update_asana, send_email],
-        # "Statuses.DATASET_PROCESSING": [set_entity_api_status],
-    }
-    """
-
-    def on_status_change(self) -> None:
-        if self.status in self.status_map:
-            for func in self.status_map[self.status]:
-                func(self)
-        else:
-            self.set_entity_api_status()
-            self.send_email()
-            self.update_asana()

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -105,7 +105,7 @@ class EntityUpdater:
             raise EntityUpdateException(
                 f"""
                 Encountered error with request to change fields {', '.join([key for key in self.fields_to_change])}
-                for {self.uuid}, fields (likely) not changed.
+                for {self.uuid}, fields either not changed or not updated completely.
                 Error: {e}
                 """
             )

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -3,145 +3,146 @@ from __future__ import annotations
 import json
 import logging
 from functools import cached_property
-from typing import Literal, Optional
-
-from status_utils import ENTITY_STATUS_MAP, Statuses, get_submission_context
+from typing import Literal, Optional, Union
 
 from airflow.providers.http.hooks.http import HttpHook
 
-# class EntityUpdateException(Exception):
-#     pass
-#
-#
-# class EntityUpdater:
-#     def __init__(
-#         self,
-#         uuid: str,
-#         token: str,
-#         http_conn_id: str = "entity_api_connection",
-#         fields_to_overwrite: Optional[dict] = None,
-#         fields_to_append_to: Optional[dict] = None,
-#         delimiter: str = "|",
-#         extra_options: Optional[dict] = None,
-#         verbose: bool = True,
-#     ):
-#         self.uuid = uuid
-#         self.token = token
-#         self.http_conn_id = http_conn_id
-#         self.fields_to_overwrite = fields_to_overwrite if fields_to_overwrite else {}
-#         self.fields_to_append_to = fields_to_append_to if fields_to_append_to else {}
-#         self.delimiter = delimiter
-#         self.extra_options = extra_options if extra_options else {}
-#         self.verbose = verbose
-#         self.entity_type = self.get_entity_type()
-#
-# @cached_property
-# def entity_data(self):
-#     return get_submission_context(self.token, self.uuid)
-#
-# def get_entity_type(self):
-#     try:
-#         entity_type = self.entity_data["entity_type"]
-#         assert entity_type is not None
-#         return entity_type
-#     except Exception as e:
-#         raise EntityUpdateException(
-#             f"""
-#             Could not find entity type for {self.uuid}.
-#             Error {e}
-#             """
-#         )
-#
-# @cached_property
-# def fields_to_change(self) -> dict:
-#     # TODO: check directionality on this
-#     duplicates = set(self.fields_to_overwrite.keys()).intersection(
-#         set(self.fields_to_append_to.keys())
-#     )
-#     assert (
-#         not duplicates
-#     ), f"Field(s) {', '.join(duplicates)} cannot be both appended to and overwritten."
-#     return self._update_existing_values() | self.fields_to_overwrite
-#
-# def update(self):
-#     """
-#     This is the main method for using the EntityUpdater.
-#     - Appends values of fields_to_append_to to existing entity-api fields.
-#     - Compiles fields to change: fields_to_overwrite + appended fields,
-#       ensuring there are no duplicates.
-#     - Validates existence of fields_to_change against fields in entity-api data.
-#     - If send_to_status_changer and "status" is found in fields_to_change,
-#       creates a StatusChanger instance and passes validated data.
-#     - Otherwise, makes a PUT request with fields_to_change payload to entity-api.
-#     - Returns response.json() or raises Exception.
-#     """
-#     self._validate_fields_to_change()
-#     self._set_entity_api_data()
-#
-# def _set_entity_api_data(self) -> dict:
-#     endpoint = f"/entities/{self.uuid}"
-#     headers = {
-#         "authorization": "Bearer " + self.token,
-#         "X-Hubmap-Application": "ingest-pipeline",
-#         "content-type": "application/json",
-#     }
-#     http_hook = HttpHook("PUT", http_conn_id=self.http_conn_id)
-#     if self.extra_options.get("check_response") is None:
-#         self.extra_options.update({"check_response": True})
-#     logging.info(
-#         f"""
-#         data:
-#         {self.fields_to_change}
-#         """
-#     )
-#     if self.verbose:
-#         logging.info(f"Updating {self.uuid} with data {self.fields_to_change}...")
-#     try:
-#         response = http_hook.run(
-#             endpoint, json.dumps(self.fields_to_change), headers, self.extra_options
-#         )
-#     except Exception as e:
-#         raise EntityUpdateException(
-#             f"""
-#             Encountered error with request to change fields {', '.join([key for key in self.fields_to_change])}
-#             for {self.uuid}, fields (likely) not changed.
-#             Error: {e}
-#             """
-#         )
-#     logging.info(f"""Response: {response.json()}""")
-#     return response.json()
-#
-# def _validate_fields_to_change(self):
-#     # TODO: this does basic key checking but should it also try to check value type?
-#     status_found = False
-#     for field in self.fields_to_change.keys():
-#         if field not in self.entity_data.keys():
-#             raise Exception(f"Field {field} is invalid for entity type {self.entity_type}.")
-#         elif field == "status":
-#             status_found = True
-#     if status_found:
-#         logging.info("'status' found in update fields, sending to StatusChanger.")
-#         StatusChanger(
-#             self.uuid,
-#             self.token,
-#             self.http_conn_id,
-#             self.fields_to_overwrite,
-#             self.fields_to_append_to,
-#             self.delimiter,
-#             self.extra_options,
-#             self.verbose,
-#             self.fields_to_change["status"],
-#             self.entity_type,
-#         ).update()
-#
-# def _update_existing_values(self):
-#     # TODO: appropriate append formatting? only certain fields allowed?
-#     new_field_data = {}
-#     for field, value in self.fields_to_append_to.items():
-#         existing_field_data = self.entity_data[field]
-#         new_field_data[field] = existing_field_data + f" {self.delimiter} " + value
-#     return new_field_data
-#
+from .status_utils import ENTITY_STATUS_MAP, Statuses, get_submission_context
+
+
+class EntityUpdateException(Exception):
+    pass
+
+
+class EntityUpdater:
+    def __init__(
+        self,
+        uuid: str,
+        token: str,
+        http_conn_id: str = "entity_api_connection",
+        fields_to_overwrite: Optional[dict] = None,
+        fields_to_append_to: Optional[dict] = None,
+        delimiter: str = "|",
+        extra_options: Optional[dict] = None,
+        verbose: bool = True,
+    ):
+        self.uuid = uuid
+        self.token = token
+        self.http_conn_id = http_conn_id
+        self.fields_to_overwrite = fields_to_overwrite if fields_to_overwrite else {}
+        self.fields_to_append_to = fields_to_append_to if fields_to_append_to else {}
+        self.delimiter = delimiter
+        self.extra_options = extra_options if extra_options else {}
+        self.verbose = verbose
+        self.entity_type = self.get_entity_type()
+
+    @cached_property
+    def entity_data(self):
+        return get_submission_context(self.token, self.uuid)
+
+    def get_entity_type(self):
+        try:
+            entity_type = self.entity_data["entity_type"]
+            assert entity_type is not None
+            return entity_type
+        except Exception as e:
+            raise EntityUpdateException(
+                f"""
+                Could not find entity type for {self.uuid}.
+                Error {e}
+                """
+            )
+
+    @cached_property
+    def fields_to_change(self) -> dict:
+        # TODO: check directionality on this
+        duplicates = set(self.fields_to_overwrite.keys()).intersection(
+            set(self.fields_to_append_to.keys())
+        )
+        assert (
+            not duplicates
+        ), f"Field(s) {', '.join(duplicates)} cannot be both appended to and overwritten."
+        return self._update_existing_values() | self.fields_to_overwrite
+
+    def update(self):
+        """
+        This is the main method for using the EntityUpdater.
+        - Appends values of fields_to_append_to to existing entity-api fields.
+        - Compiles fields to change: fields_to_overwrite + appended fields,
+        ensuring there are no duplicates.
+        - Validates existence of fields_to_change against fields in entity-api data.
+        - If send_to_status_changer and "status" is found in fields_to_change,
+        creates a StatusChanger instance and passes validated data.
+        - Otherwise, makes a PUT request with fields_to_change payload to entity-api.
+        - Returns response.json() or raises Exception.
+        """
+        self._validate_fields_to_change()
+        self._set_entity_api_data()
+
+    def _set_entity_api_data(self) -> dict:
+        endpoint = f"/entities/{self.uuid}"
+        headers = {
+            "authorization": "Bearer " + self.token,
+            "X-Hubmap-Application": "ingest-pipeline",
+            "content-type": "application/json",
+        }
+        http_hook = HttpHook("PUT", http_conn_id=self.http_conn_id)
+        if self.extra_options.get("check_response") is None:
+            self.extra_options.update({"check_response": True})
+        logging.info(
+            f"""
+            data:
+            {self.fields_to_change}
+            """
+        )
+        if self.verbose:
+            logging.info(f"Updating {self.uuid} with data {self.fields_to_change}...")
+        try:
+            response = http_hook.run(
+                endpoint, json.dumps(self.fields_to_change), headers, self.extra_options
+            )
+        except Exception as e:
+            raise EntityUpdateException(
+                f"""
+                Encountered error with request to change fields {', '.join([key for key in self.fields_to_change])}
+                for {self.uuid}, fields (likely) not changed.
+                Error: {e}
+                """
+            )
+        logging.info(f"""Response: {response.json()}""")
+        return response.json()
+
+    def _validate_fields_to_change(self):
+        # TODO: this does basic key checking but should it also try to check value type?
+        status_found = False
+        for field in self.fields_to_change.keys():
+            if field not in self.entity_data.keys():
+                raise Exception(f"Field {field} is invalid for entity type {self.entity_type}.")
+            elif field == "status":
+                status_found = True
+        if status_found:
+            logging.info("'status' found in update fields, sending to StatusChanger.")
+            StatusChanger(
+                self.uuid,
+                self.token,
+                self.http_conn_id,
+                self.fields_to_overwrite,
+                self.fields_to_append_to,
+                self.delimiter,
+                self.extra_options,
+                self.verbose,
+                self.fields_to_change["status"],
+                self.entity_type,
+            ).update()
+
+    def _update_existing_values(self):
+        # TODO: appropriate append formatting? only certain fields allowed?
+        new_field_data = {}
+        for field, value in self.fields_to_append_to.items():
+            existing_field_data = self.entity_data[field]
+            new_field_data[field] = existing_field_data + f" {self.delimiter} " + value
+        return new_field_data
+
 
 """
 Example usage, simple path (e.g. status string, no validation message):
@@ -181,7 +182,7 @@ class StatusChanger:
         extra_options: Optional[dict] = None,
         verbose: bool = True,
         # Additional fields added to support privileged field "status"
-        status: Optional[Statuses | str] = None,
+        status: Optional[Union[Statuses, str]] = None,
         entity_type: Optional[Literal["Dataset", "Upload", "Publication"]] = None,
     ):
         self.uuid = uuid

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -55,7 +55,6 @@ class EntityUpdater:
 
     @cached_property
     def fields_to_change(self) -> dict:
-        # TODO: check directionality on this
         duplicates = set(self.fields_to_overwrite.keys()).intersection(
             set(self.fields_to_append_to.keys())
         )

--- a/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
@@ -1,12 +1,76 @@
 from __future__ import annotations
 
 import traceback
+from enum import Enum
 from typing import Any, Dict
 
 from requests import codes
 from requests.exceptions import HTTPError
 
 from airflow.hooks.http_hook import HttpHook
+
+
+class Statuses(str, Enum):
+    # Dataset Hold and Deprecated are not currently in use but are valid for Entity API
+    DATASET_DEPRECATED = "deprecated"
+    DATASET_ERROR = "error"
+    DATASET_HOLD = "hold"
+    DATASET_INVALID = "invalid"
+    DATASET_NEW = "new"
+    DATASET_PROCESSING = "processing"
+    DATASET_PUBLISHED = "published"
+    DATASET_QA = "qa"
+    DATASET_SUBMITTED = "submitted"
+    PUBLICATION_ERROR = "error"
+    PUBLICATION_HOLD = "hold"
+    PUBLICATION_INVALID = "invalid"
+    PUBLICATION_NEW = "new"
+    PUBLICATION_PROCESSING = "processing"
+    PUBLICATION_PUBLISHED = "published"
+    PUBLICATION_QA = "qa"
+    PUBLICATION_SUBMITTED = "submitted"
+    UPLOAD_ERROR = "error"
+    UPLOAD_INVALID = "invalid"
+    UPLOAD_NEW = "new"
+    UPLOAD_PROCESSING = "processing"
+    UPLOAD_REORGANIZED = "reorganized"
+    UPLOAD_SUBMITTED = "submitted"
+    UPLOAD_VALID = "valid"
+
+
+# Needed some way to disambiguate statuses shared by datasets and uploads
+ENTITY_STATUS_MAP = {
+    "dataset": {
+        "deprecated": Statuses.DATASET_DEPRECATED,
+        "error": Statuses.DATASET_ERROR,
+        "hold": Statuses.DATASET_HOLD,
+        "invalid": Statuses.DATASET_INVALID,
+        "new": Statuses.DATASET_NEW,
+        "processing": Statuses.DATASET_PROCESSING,
+        "published": Statuses.DATASET_PUBLISHED,
+        "qa": Statuses.DATASET_QA,
+        "submitted": Statuses.DATASET_SUBMITTED,
+    },
+    "publication": {
+        "error": Statuses.PUBLICATION_ERROR,
+        "hold": Statuses.PUBLICATION_HOLD,
+        "invalid": Statuses.PUBLICATION_INVALID,
+        "new": Statuses.PUBLICATION_NEW,
+        "processing": Statuses.PUBLICATION_PROCESSING,
+        "published": Statuses.PUBLICATION_PUBLISHED,
+        "qa": Statuses.PUBLICATION_QA,
+        "submitted": Statuses.PUBLICATION_SUBMITTED,
+    },
+    "upload": {
+        "error": Statuses.UPLOAD_ERROR,
+        "invalid": Statuses.UPLOAD_INVALID,
+        "new": Statuses.UPLOAD_NEW,
+        "processing": Statuses.UPLOAD_PROCESSING,
+        "reorganized": Statuses.UPLOAD_REORGANIZED,
+        "submitted": Statuses.UPLOAD_SUBMITTED,
+        "valid": Statuses.UPLOAD_VALID,
+    },
+}
 
 
 # This is simplified from pythonop_get_dataset_state in utils

--- a/src/ingest-pipeline/airflow/dags/status_change/tests/test_status_changer.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/tests/test_status_changer.py
@@ -251,6 +251,6 @@ class TestEntityUpdater(unittest.TestCase):
             )
 
 
-if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestEntityUpdater)
-    suite.debug()
+# if __name__ == "__main__":
+#     suite = unittest.TestLoader().loadTestsFromTestCase(TestEntityUpdater)
+#     suite.debug()

--- a/src/ingest-pipeline/airflow/dags/status_change/tests/test_status_changer.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/tests/test_status_changer.py
@@ -2,71 +2,142 @@ import unittest
 from functools import cached_property
 from unittest.mock import patch
 
-from status_manager import StatusChanger, StatusChangerException, Statuses
+from status_manager import EntityUpdateException, EntityUpdater, StatusChanger, Statuses
 from utils import pythonop_set_dataset_state
 
 
-class TestStatusChanger(unittest.TestCase):
+class TestEntityUpdater(unittest.TestCase):
+    validation_msg = "Test validation message"
+    ingest_task = "Plugins passed: test_1, test_2"
+    good_context = {
+        "validation_message": "existing validation_message text",
+        "ingest_task": "existing ingest_task text",
+        "unrelated_field": True,
+        "entity_type": "Upload",
+        "status": "new",
+    }
+
     @cached_property
-    @patch("status_manager.HttpHook.run")
-    def upload_valid(self, hhr_mock):
-        return StatusChanger(
+    @patch("status_manager.get_submission_context")
+    def upload_entity_valid(self, context_mock):
+        context_mock.return_value = self.good_context
+        return EntityUpdater(
             "upload_valid_uuid",
             "upload_valid_token",
-            status="Valid",
-            extra_options={},
-            entity_type="Upload",
+            fields_to_overwrite={"validation_message": self.validation_msg},
+            fields_to_append_to={"ingest_task": self.ingest_task},
         )
 
+    def test_get_entity_type(self):
+        assert self.upload_entity_valid.entity_type == "Upload"
+
+    def test_fields_to_change(self):
+        assert self.upload_entity_valid.fields_to_change == {
+            "ingest_task": f"existing ingest_task text | {self.ingest_task}",
+            "validation_message": self.validation_msg,
+        }
+
+    @patch("status_manager.EntityUpdater._validate_fields_to_change")
     @patch("status_manager.HttpHook.run")
-    def test_unrecognized_status(self, hhr_mock):
-        with self.assertRaises(StatusChangerException):
-            StatusChanger(
-                "invalid_status_uuid",
-                "invalid_status_token",
-                status="invalid_status_string",
+    def test_update(self, hhr_mock, validate_mock):
+        hhr_mock.assert_not_called()
+        validate_mock.assert_not_called()
+        self.upload_entity_valid.update()
+        validate_mock.assert_called_once()
+        hhr_mock.assert_called_once()
+
+    @patch("status_manager.StatusChanger")
+    @patch("status_manager.get_submission_context")
+    def test_pass_to_statuschanger(self, context_mock, statuschanger_mock):
+        context_mock.return_value = self.good_context
+        with_status = EntityUpdater(
+            "upload_valid_uuid",
+            "upload_valid_token",
+            fields_to_overwrite={"status": "valid", "validation_message": self.validation_msg},
+            fields_to_append_to={"ingest_task": self.ingest_task},
+        )
+        with patch("status_manager.HttpHook.run"):
+            with_status._validate_fields_to_change()
+        assert statuschanger_mock.called_once_with(
+            "upload_valid_uuid",
+            "upload_valid_token",
+            with_status.http_conn_id,
+            {"validation_message": self.validation_msg},
+            with_status.fields_to_append_to,
+            with_status.delimiter,
+            with_status.extra_options,
+            with_status.verbose,
+            "valid",
+            with_status.entity_type,
+        )
+
+    @cached_property
+    def upload_valid(self):
+        with patch("status_manager.get_submission_context"):
+            return StatusChanger(
+                "upload_valid_uuid",
+                "upload_valid_token",
+                status="Valid",
                 extra_options={},
                 entity_type="Upload",
             )
+
+    def test_unrecognized_status(self):
+        with patch("status_manager.get_submission_context"):
+            with self.assertRaises(EntityUpdateException):
+                StatusChanger(
+                    "invalid_status_uuid",
+                    "invalid_status_token",
+                    status="invalid_status_string",
+                    extra_options={},
+                    entity_type="Upload",
+                )
 
     def test_recognized_status(self):
         self.upload_valid._validate_fields_to_change()
         self.assertEqual(self.upload_valid.fields_to_change["status"], self.upload_valid.status)
 
-    @patch("status_manager.HttpHook.run")
-    def test_extra_fields(self, hhr_mock):
-        with_extra_field = StatusChanger(
-            "extra_field_uuid",
-            "extra_field_token",
-            status=Statuses.UPLOAD_PROCESSING,
-            fields_to_overwrite={"test_extra_field": True},
-        )
-        data = with_extra_field.fields_to_change
-        self.assertIn("test_extra_field", data)
-        self.assertEqual(data["test_extra_field"], True)
+    def test_extra_fields(self):
+        with patch("status_manager.get_submission_context"):
+            with_extra_field = StatusChanger(
+                "extra_field_uuid",
+                "extra_field_token",
+                status=Statuses.UPLOAD_PROCESSING,
+                fields_to_overwrite={"test_extra_field": True},
+            )
+            data = with_extra_field.fields_to_change
+            self.assertIn("test_extra_field", data)
+            self.assertEqual(data["test_extra_field"], True)
 
     @patch("status_manager.HttpHook.run")
     def test_extra_options(self, hhr_mock):
-        with_extra_option = StatusChanger(
-            "extra_options_uuid",
-            "extra_options_token",
-            status=Statuses.UPLOAD_VALID,
-            extra_options={"check_response": False},
-            verbose=False,
-        )
-        with_extra_option._set_entity_api_data()
-        self.assertIn({"check_response": False}, hhr_mock.call_args.args)
-        without_extra_option = StatusChanger(
-            "extra_options_uuid",
-            "extra_options_token",
-            status=Statuses.UPLOAD_VALID,
-            verbose=False,
-        )
-        without_extra_option._set_entity_api_data()
-        self.assertIn({"check_response": True}, hhr_mock.call_args.args)
+        with patch("status_manager.get_submission_context"):
+            with_extra_option = StatusChanger(
+                "extra_options_uuid",
+                "extra_options_token",
+                status=Statuses.UPLOAD_VALID,
+                extra_options={"check_response": False},
+                verbose=False,
+            )
+            with_extra_option._set_entity_api_data()
+            self.assertIn({"check_response": False}, hhr_mock.call_args.args)
+            without_extra_option = StatusChanger(
+                "extra_options_uuid",
+                "extra_options_token",
+                status=Statuses.UPLOAD_VALID,
+                verbose=False,
+            )
+            without_extra_option._set_entity_api_data()
+            self.assertIn({"check_response": True}, hhr_mock.call_args.args)
 
+    @patch("status_manager.get_submission_context")
     @patch("status_manager.HttpHook.run")
-    def test_extra_options_and_fields(self, hhr_mock):
+    def test_extra_options_and_fields_good(self, hhr_mock, context_mock):
+        context_mock.return_value = {
+            "status": "processing",
+            "entity_type": "Upload",
+            "test_extra_field": False,
+        }
         with_extra_option_and_field = StatusChanger(
             "extra_options_uuid",
             "extra_options_token",
@@ -77,7 +148,24 @@ class TestStatusChanger(unittest.TestCase):
         )
         with_extra_option_and_field.update()
         self.assertIn({"check_response": False}, hhr_mock.call_args.args)
-        self.assertIn('{"status": "valid", "test_extra_field": true}', hhr_mock.call_args.args)
+        self.assertIn('{"test_extra_field": true, "status": "valid"}', hhr_mock.call_args.args)
+
+    @patch("status_manager.get_submission_context")
+    @patch("status_manager.HttpHook.run")
+    def test_extra_fields_bad(self, hhr_mock, context_mock):
+        context_mock.return_value = {
+            "status": "processing",
+            "entity_type": "Upload",
+        }
+        with_extra_option_and_field = StatusChanger(
+            "extra_options_uuid",
+            "extra_options_token",
+            status=Statuses.UPLOAD_VALID,
+            fields_to_overwrite={"test_extra_field": True},
+            verbose=False,
+        )
+        self.assertRaises(Exception, with_extra_option_and_field.update)
+        hhr_mock.assert_not_called()
 
     @patch("status_manager.HttpHook.run")
     def test_valid_status_in_request(self, hhr_mock):
@@ -85,23 +173,23 @@ class TestStatusChanger(unittest.TestCase):
         self.upload_valid._set_entity_api_data()
         self.assertIn('{"status": "valid"}', hhr_mock.call_args.args)
 
-    @patch("status_manager.HttpHook.run")
-    def test_http_conn_id(self, hhr_mock):
-        with_http_conn_id = StatusChanger(
-            "http_conn_uuid",
-            "http_conn_token",
-            status=Statuses.DATASET_NEW,
-            http_conn_id="test_conn_id",
-        )
-        assert with_http_conn_id.http_conn_id == "test_conn_id"
+    def test_http_conn_id(self):
+        with patch("status_manager.HttpHook.run"):
+            with_http_conn_id = StatusChanger(
+                "http_conn_uuid",
+                "http_conn_token",
+                status=Statuses.DATASET_NEW,
+                http_conn_id="test_conn_id",
+            )
+            assert with_http_conn_id.http_conn_id == "test_conn_id"
 
-    @patch("status_manager.HttpHook.run")
     @patch("status_manager.StatusChanger.send_email")
-    def test_status_map(self, send_email_mock, hhr_mock):
+    def test_update_from_status_map(self, send_email_mock):
         self.assertFalse(send_email_mock.called)
         self.assertEqual(self.upload_valid.status, Statuses.UPLOAD_VALID)
         self.upload_valid.status_map = {Statuses.UPLOAD_VALID: [self.upload_valid.send_email]}
-        self.upload_valid.update()
+        with patch("status_manager.HttpHook.run"):
+            self.upload_valid.update()
         self.assertTrue(send_email_mock.called)
 
     @staticmethod
@@ -161,3 +249,8 @@ class TestStatusChanger(unittest.TestCase):
                 message=message,
                 ds_state="Unknown",
             )
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestEntityUpdater)
+    suite.debug()

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -36,7 +36,7 @@ from hubmap_commons.schema_tools import assert_json_matches_schema, set_schema_b
 from hubmap_commons.type_client import TypeClient
 from requests import codes
 from requests.exceptions import HTTPError
-from status_change.status_manager import StatusChanger
+from status_change.status_manager import EntityUpdateException, StatusChanger
 
 from airflow import DAG
 from airflow.configuration import conf as airflow_conf
@@ -1466,7 +1466,7 @@ def make_send_status_msg_function(
                     fields_to_overwrite=extra_fields,
                     entity_type=entity_type if entity_type else None,
                 ).update()
-            except Exception:
+            except EntityUpdateException:
                 return_status = False
 
         return return_status

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -36,7 +36,7 @@ from hubmap_commons.schema_tools import assert_json_matches_schema, set_schema_b
 from hubmap_commons.type_client import TypeClient
 from requests import codes
 from requests.exceptions import HTTPError
-from status_change.status_manager import EntityUpdateException, StatusChanger
+from status_change.status_manager import StatusChanger
 
 from airflow import DAG
 from airflow.configuration import conf as airflow_conf
@@ -1466,7 +1466,7 @@ def make_send_status_msg_function(
                     fields_to_overwrite=extra_fields,
                     entity_type=entity_type if entity_type else None,
                 ).update()
-            except EntityUpdateException:
+            except Exception:
                 return_status = False
 
         return return_status

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -36,7 +36,7 @@ from hubmap_commons.schema_tools import assert_json_matches_schema, set_schema_b
 from hubmap_commons.type_client import TypeClient
 from requests import codes
 from requests.exceptions import HTTPError
-from status_change.status_manager import StatusChanger, StatusChangerException
+from status_change.status_manager import EntityUpdateException, StatusChanger
 
 from airflow import DAG
 from airflow.configuration import conf as airflow_conf
@@ -1466,7 +1466,7 @@ def make_send_status_msg_function(
                     fields_to_overwrite=extra_fields,
                     entity_type=entity_type if entity_type else None,
                 ).update()
-            except StatusChangerException:
+            except EntityUpdateException:
                 return_status = False
 
         return return_status

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -892,13 +892,10 @@ def pythonop_set_dataset_state(**kwargs) -> None:
     StatusChanger(
         dataset_uuid,
         get_auth_tok(**kwargs),
-        status,
-        {
-            "extra_fields": {"pipeline_message": message} if message else {},
-            "extra_options": {},
-        },
+        status=status,
+        fields_to_overwrite={"pipeline_message": message} if message else {},
         http_conn_id=http_conn_id,
-    ).on_status_change()
+    ).update()
 
 
 def restructure_entity_metadata(raw_metadata: JSONType) -> JSONType:
@@ -1463,16 +1460,12 @@ def make_send_status_msg_function(
         entity_type = ds_rslt.get("entity_type")
         if status:
             try:
-                StatusChanger(
-                    dataset_uuid,
+                StatusChanger( dataset_uuid,
                     get_auth_tok(**kwargs),
-                    status,
-                    {
-                        "extra_fields": extra_fields,
-                        "extra_options": {},
-                    },
+                    status=status,
+                    fields_to_overwrite=extra_fields,
                     entity_type=entity_type if entity_type else None,
-                ).on_status_change()
+                ).update()
             except StatusChangerException:
                 return_status = False
 

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -162,12 +162,9 @@ with HMDAG(
         StatusChanger(
             kwargs["ti"].xcom_pull(key="uuid"),
             get_auth_tok(**kwargs),
-            status,
-            {
-                "extra_fields": extra_fields,
-                "extra_options": {},
-            },
-        ).on_status_change()
+            status=status,
+            fields_to_overwrite=extra_fields,
+        ).update()
 
     t_send_status = PythonOperator(
         task_id="send_status",

--- a/src/ingest-pipeline/misc/tools/split_and_create.py
+++ b/src/ingest-pipeline/misc/tools/split_and_create.py
@@ -3,17 +3,17 @@
 import argparse
 import json
 import re
-import os
 import time
 from pathlib import Path
 from pprint import pprint
 from shutil import copy2, copytree
-from typing import List, TypeVar, Union, Tuple
+from typing import List, Tuple, TypeVar, Union
 
 import pandas as pd
-from status_change.status_manager import StatusChanger, Statuses
-from airflow.hooks.http_hook import HttpHook
 from extra_utils import SoftAssayClient
+from status_change.status_manager import StatusChanger, Statuses
+
+from airflow.hooks.http_hook import HttpHook
 
 # There has got to be a better solution for this, but I can't find it
 try:
@@ -381,13 +381,10 @@ def update_upload_entity(child_uuid_list, source_entity, dryrun=False, verbose=F
             StatusChanger(
                 source_entity.uuid,
                 source_entity.entity_factory.auth_tok,
-                Statuses.UPLOAD_REORGANIZED,
-                {
-                    "extra_fields": {"dataset_uuids_to_link": child_uuid_list},
-                    "extra_options": {},
-                },
+                status=Statuses.UPLOAD_REORGANIZED,
+                fields_to_overwrite={"dataset_uuids_to_link": child_uuid_list},
                 verbose=verbose,
-            ).on_status_change()
+            ).update()
             print(f"{source_entity.uuid} status is Reorganized")
 
             # TODO: click in with UpdateAsana
@@ -396,9 +393,9 @@ def update_upload_entity(child_uuid_list, source_entity, dryrun=False, verbose=F
                 StatusChanger(
                     uuid,
                     source_entity.entity_factory.auth_tok,
-                    Statuses.DATASET_SUBMITTED,
+                    status=Statuses.DATASET_SUBMITTED,
                     verbose=verbose,
-                ).on_status_change()
+                ).update()
                 print(
                     f"Reorganized new: {uuid} from Upload: {source_entity.uuid} status is Submitted"
                 )
@@ -583,9 +580,9 @@ def reorganize_multiassay(source_uuid, verbose=False, **kwargs) -> None:
     StatusChanger(
         source_entity.uuid,
         source_entity.entity_factory.auth_tok,
-        Statuses.DATASET_SUBMITTED,
+        status=Statuses.DATASET_SUBMITTED,
         verbose=verbose,
-    ).on_status_change()
+    ).update()
     print(f"{source_entity.uuid} status is Submitted")
 
 


### PR DESCRIPTION
This PR adds the ability to append to fields in Entity API rather than overwriting them. I've abstracted the field updating logic upward into a new class, EntityUpdater, and made StatusChanger a specialized subclass.

## Look at ##
- `status_manager.py` - contains the updates to StatusChanger and the new EntityUpdater class.

## Extra features ##
- EntityUpdater will pass args off to StatusChanger if a status is passed to it.
- StatusChanger will pass args off to EntityUpdater if it is not passed a status or if the status in Entity API is the same (which avoids an error caused by a PUT request to update the status with the same value).
- Can specify which fields you want to overwrite vs. append to.
     - If a field is in both lists, an exception is thrown.
- Can pass custom delimiters (although they would apply to all appended-to fields, there's no specificity built in currently).

## Other updates ##
- Maps and enums moved to `status_utils.py`.
- Instantiations of `StatusChanger` updated.
- Tests updated.
- `.gitignore` updated because untracked files were annoying me.

## QUESTIONS ##
- How do we feel about the `|` delimiter?
- I do not have the read-only fields defined, currently an error thrown by Entity API because you tried to write to a read-only field will be bubbled up as an `EntityUpdateException`. Does that seem okay?