### PR TITLE
Welling/state add mouse

### DIFF
--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1018,6 +1018,19 @@ def pythonop_get_dataset_state(**kwargs) -> Dict:
     }
 
     if ds_rslt["entity_type"] == "Dataset":
+        unique_source_types = set()
+        if sources := ds_rslt.get("sources"):
+            rslt["sources"] = sources
+            for source in sources:
+                unique_source_types.add(source.get("source_type", "Human").lower())
+        if not unique_source_types:
+            species = "human"
+        elif len(unique_source_types) == 1:
+            species = unique_source_types.pop()
+        else:
+            species = "mixed"
+        rslt["species"] = species
+
         http_hook = HttpHook("GET", http_conn_id="entity_api_connection")
         endpoint = f"datasets/{ds_rslt['uuid']}/organs"
         try:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1473,7 +1473,8 @@ def make_send_status_msg_function(
         entity_type = ds_rslt.get("entity_type")
         if status:
             try:
-                StatusChanger( dataset_uuid,
+                StatusChanger(
+                    dataset_uuid,
                     get_auth_tok(**kwargs),
                     status=status,
                     fields_to_overwrite=extra_fields,


### PR DESCRIPTION
This PR modifies utils:pythonop_get_dataset_state() to add "sources" and "species" to Datasets.  "sources" is a direct copy of the sources provided by entity-api if present, and undefined otherwise.  "species" is one of "human", "mouse", "mixed".