### PR TITLE
StatusChanger bugfix for None status

### DIFF
--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -238,6 +238,9 @@ class StatusChanger:
                 self.verbose,
             ).update()
             return
+        elif self.status is None and not self.fields_to_change:
+            logging.info(f"No status to update or fields to change for {self.uuid}, not making any changes in entity-api.")
+            return
         self._validate_fields_to_change()
         if self.status in self.status_map:
             for func in self.status_map[self.status]:


### PR DESCRIPTION
Catching case in `StatusChanger.update` where status is None and there are no other fields to change. Previously this would throw an exception because this is a bad call to entity-api, now it should log that no call was made.