### PR TITLE
Centralized parameter relax-path-checks

### DIFF
--- a/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
@@ -248,7 +248,6 @@ with HMDAG(
         # this is the call to the CWL
         command = [
             *get_cwltool_base_cmd(tmpdir),
-            "--relax-path-checks",
             cwl_workflows["ome_tiff_pyramid"],
             "--ometiff_directory",
             ".",

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -394,7 +394,6 @@ with HMDAG('codex_cytokit',
         # this is the call to the CWL
         command = [
             *get_cwltool_base_cmd(tmpdir),
-            '--relax-path-checks',
             cwl_workflows['ome_tiff_pyramid'],
             '--ometiff_directory',
             '.',

--- a/src/ingest-pipeline/airflow/dags/mibi_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/mibi_deepcell.py
@@ -241,7 +241,6 @@ with HMDAG('mibi_deepcell',
         # this is the call to the CWL
         command = [
             *get_cwltool_base_cmd(tmpdir),
-            '--relax-path-checks',
             cwl_workflows['ome_tiff_pyramid'],
             '--ometiff_directory',
             '.',

--- a/src/ingest-pipeline/airflow/dags/multiome.py
+++ b/src/ingest-pipeline/airflow/dags/multiome.py
@@ -123,7 +123,6 @@ def generate_multiome_dag(params: MultiomeSequencingDagParameters) -> DAG:
 
             command = [
                 *get_cwltool_base_cmd(tmpdir),
-                "--relax-path-checks",
                 "--outdir",
                 tmpdir / "cwl_out",
                 "--parallel",

--- a/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
+++ b/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
@@ -144,7 +144,6 @@ with HMDAG(
         # this is the call to the CWL
         command = [
             *get_cwltool_base_cmd(tmpdir),
-            "--relax-path-checks",
             cwl_workflows["ome_tiff_pyramid"],
             "--ometiff_directory",
             ".",

--- a/src/ingest-pipeline/airflow/dags/phenocycler_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/phenocycler_deepcell.py
@@ -241,7 +241,6 @@ with HMDAG(
         # this is the call to the CWL
         command = [
             *get_cwltool_base_cmd(tmpdir),
-            "--relax-path-checks",
             cwl_workflows["ome_tiff_pyramid"],
             "--ometiff_directory",
             ".",

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
@@ -105,7 +105,6 @@ def generate_salmon_rnaseq_dag(params: SequencingDagParameters) -> DAG:
 
             command = [
                 *get_cwltool_base_cmd(tmpdir),
-                "--relax-path-checks",
                 "--outdir",
                 tmpdir / "cwl_out",
                 "--parallel",

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1235,6 +1235,7 @@ def get_cwltool_base_cmd(tmpdir: Path) -> List[str]:
         # are created as *subdirectories* of 'cwl-tmp' and 'cwl-out-tmp'.
         "--tmpdir-prefix={}/".format(tmpdir / "cwl-tmp"),
         "--tmp-outdir-prefix={}/".format(tmpdir / "cwl-out-tmp"),
+        "--relax-path-checks",
     ]
 
 

--- a/src/ingest-pipeline/airflow/dags/visium.py
+++ b/src/ingest-pipeline/airflow/dags/visium.py
@@ -105,7 +105,6 @@ with HMDAG(
 
         command = [
             *get_cwltool_base_cmd(tmpdir),
-            "--relax-path-checks",
             "--outdir",
             tmpdir / "cwl_out",
             "--parallel",
@@ -175,7 +174,6 @@ with HMDAG(
         # this is the call to the CWL
         command = [
             *get_cwltool_base_cmd(tmpdir),
-            "--relax-path-checks",
             cwl_workflows[3],
             "--ometiff_directory",
             data_dir / "lab_processed/images/",


### PR DESCRIPTION
Centralized parameter --relax-path-checks for cwlTool.
Bumping portal containers to support this parameter.