### PR TITLE
Bump salmon-rnaseq v2.2.9

### DIFF
--- a/src/ingest-pipeline/airflow/dags/workflow_map.yml
+++ b/src/ingest-pipeline/airflow/dags/workflow_map.yml
@@ -66,7 +66,7 @@ workflow_map:
     'assay_type': 'sciATACseq'
     'workflow': 'sc_atac_seq_sci'
   - 'collection_type': 'generic_metadatatsv'
-    'assay_type': 'bulk RNA'
+    'assay_type': 'bulk-RNA'
     'workflow': 'salmon_rnaseq_bulk'
   - 'collection_type': 'generic_metadatatsv'
     'assay_type': 'sciRNAseq'


### PR DESCRIPTION
Bump salmon-rnaseq to v2.2.9 with organism support.
Bugfix for updated assay_type definition of bulkRNA (bulk-RNA)