### PR TITLE
Pass thread count to CWL

### DIFF
--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -30,6 +30,7 @@ from utils import (
     get_tmp_dir_path,
     HMDAG,
     get_queue_resource,
+    get_threads_resource,
     get_preserve_scratch_resource,
 )
 
@@ -94,6 +95,8 @@ with HMDAG('ometiff_pyramid',
         command = [
             *get_cwltool_base_cmd(tmpdir),
             cwl_workflows[0],
+            "--processes",
+            get_threads_resource(dag.dag_id),
             '--ometiff_directory',
             data_dir,
         ]

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -31,6 +31,7 @@ from utils import (
     get_tmp_dir_path,
     HMDAG,
     get_queue_resource,
+    get_threads_resource,
     get_preserve_scratch_resource,
 )
 
@@ -98,6 +99,8 @@ with HMDAG('ometiff_pyramid_ims',
         command = [
             *get_cwltool_base_cmd(tmpdir),
             cwl_workflows[0],
+            "--processes",
+            get_threads_resource(dag.dag_id),
             '--downsample_type',
             DOWNSAMPLE_TYPE,
             '--ometiff_directory',


### PR DESCRIPTION
This PR adds handling of the threads resource to the ome_tiff_pyramid and ome_tiff_pyramid_ims DAGs.  It turns out that is all that is necessary to enable more parallelism for those tasks.