### PR TITLE
Python3.11 upgrade

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,15 +43,9 @@
 [submodule "src/ingest-pipeline/airflow/dags/cwl/cfde-bdbag"]
 	path = src/ingest-pipeline/airflow/dags/cwl/cfde-bdbag
 	url = https://github.com/hubmapconsortium/cfde-bdbag.git
-[submodule "src/ingest-pipeline/submodules/py-hubmapbags"]
-	path = src/ingest-pipeline/submodules/py-hubmapbags
-	url = https://github.com/hubmapconsortium/py-hubmapbags.git
 [submodule "src/ingest-pipeline/airflow/dags/cwl/pas-ftu-segmentation-pipeline"]
 	path = src/ingest-pipeline/airflow/dags/cwl/pas-ftu-segmentation-pipeline
 	url = https://github.com/hubmapconsortium/pas-ftu-segmentation-pipeline
-[submodule "src/ingest-pipeline/submodules/hubmap-inventory"]
-	path = src/ingest-pipeline/submodules/hubmap-inventory
-	url = https://github.com/hubmapconsortium/hubmap-inventory.git
 [submodule "src/ingest-pipeline/airflow/dags/cwl/create-vis-symlink-archive"]
 	path = src/ingest-pipeline/airflow/dags/cwl/create-vis-symlink-archive
 	url = https://github.com/hubmapconsortium/create-vis-symlink-archive.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[project]
+name="ingest-pipeline"
+requires-python="3.11"
+readme="README.md"
+license={file = "LICENSE"}
+
+[project.urls]
+homepage="https://hubmapconsortium.org"
+repository="https://github.com/hubmapconsortium/ingest-pipeline"
+
 [tool.black]
 line-length = 99
 

--- a/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
+++ b/src/ingest-pipeline/airflow/dags/azimuth_annotations.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from hubmap_operators.common_operators import (
     CleanupTmpDirOperator,
@@ -124,11 +124,11 @@ with HMDAG(
         *cwl_workflows_annotations_multiome,
     ]
 
-    prepare_cwl1 = DummyOperator(task_id="prepare_cwl1")
+    prepare_cwl1 = EmptyOperator(task_id="prepare_cwl1")
 
-    prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+    prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
-    prepare_cwl3 = DummyOperator(task_id="prepare_cwl3")
+    prepare_cwl3 = EmptyOperator(task_id="prepare_cwl3")
 
     def build_cwltool_cmd1(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/bulk_process.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_process.py
@@ -10,7 +10,7 @@ from hubmap_operators.flex_multi_dag_run import FlexMultiDagRunOperator
 import utils
 
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
     get_preserve_scratch_resource,

--- a/src/ingest-pipeline/airflow/dags/bulk_update_entities.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_update_entities.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from airflow.operators.python import PythonOperator
 from airflow.configuration import conf as airflow_conf
 from datetime import datetime
-from airflow.hooks.http_hook import HttpHook
+from airflow.providers.http.hooks.http import HttpHook
 
 from utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,

--- a/src/ingest-pipeline/airflow/dags/bulk_update_entities.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_update_entities.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from airflow.providers.http.hooks.http import HttpHook
 
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     get_preserve_scratch_resource,
     get_tmp_dir_path,
     HMDAG,

--- a/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/celldive_deepcell.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.decorators import task
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 
@@ -31,7 +31,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     LogInfoOperator,
     MoveDataOperator,
-    SetDatasetProcessingOperator,
 )
 
 from extra_utils import build_tag_containers
@@ -226,7 +225,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_create_vis_symlink_archive = DummyOperator(
+    prepare_cwl_create_vis_symlink_archive = EmptyOperator(
         task_id="prepare_cwl_create_vis_symlink_archive",
     )
 
@@ -276,7 +275,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_pyramid = DummyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
+    prepare_cwl_ome_tiff_pyramid = EmptyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
 
     def build_cwltool_cwl_ome_tiff_pyramid(**kwargs):
         run_id = kwargs["run_id"]
@@ -327,7 +326,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_offsets = DummyOperator(task_id="prepare_cwl_ome_tiff_offsets")
+    prepare_cwl_ome_tiff_offsets = EmptyOperator(task_id="prepare_cwl_ome_tiff_offsets")
 
     def build_cwltool_cmd_ome_tiff_offsets(**kwargs):
         run_id = kwargs["run_id"]
@@ -376,7 +375,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_json = DummyOperator(task_id="prepare_cwl_sprm_to_json")
+    prepare_cwl_sprm_to_json = EmptyOperator(task_id="prepare_cwl_sprm_to_json")
 
     def build_cwltool_cmd_sprm_to_json(**kwargs):
         run_id = kwargs["run_id"]
@@ -425,7 +424,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_anndata = DummyOperator(task_id="prepare_cwl_sprm_to_anndata")
+    prepare_cwl_sprm_to_anndata = EmptyOperator(task_id="prepare_cwl_sprm_to_anndata")
 
     def build_cwltool_cmd_sprm_to_anndata(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/codex_cytokit.py
+++ b/src/ingest-pipeline/airflow/dags/codex_cytokit.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator, BranchPythonOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.decorators import task
 
 from hubmap_operators.common_operators import (
@@ -11,7 +11,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     CreateTmpDirOperator,
     CleanupTmpDirOperator,
-    SetDatasetProcessingOperator,
     MoveDataOperator,
 )
 
@@ -421,7 +420,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm = DummyOperator(task_id="prepare_cwl_sprm")
+    prepare_cwl_sprm = EmptyOperator(task_id="prepare_cwl_sprm")
 
     def build_cwltool_cmd_sprm(**kwargs):
         run_id = kwargs["run_id"]
@@ -473,7 +472,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_create_vis_symlink_archive = DummyOperator(
+    prepare_cwl_create_vis_symlink_archive = EmptyOperator(
         task_id="prepare_cwl_create_vis_symlink_archive",
     )
 
@@ -522,7 +521,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_pyramid = DummyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
+    prepare_cwl_ome_tiff_pyramid = EmptyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
 
     def build_cwltool_cwl_ome_tiff_pyramid(**kwargs):
         run_id = kwargs["run_id"]
@@ -573,7 +572,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_offsets = DummyOperator(task_id="prepare_cwl_ome_tiff_offsets")
+    prepare_cwl_ome_tiff_offsets = EmptyOperator(task_id="prepare_cwl_ome_tiff_offsets")
 
     def build_cwltool_cmd_ome_tiff_offsets(**kwargs):
         run_id = kwargs["run_id"]
@@ -621,7 +620,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_json = DummyOperator(task_id="prepare_cwl_sprm_to_json")
+    prepare_cwl_sprm_to_json = EmptyOperator(task_id="prepare_cwl_sprm_to_json")
 
     def build_cwltool_cmd_sprm_to_json(**kwargs):
         run_id = kwargs["run_id"]
@@ -669,7 +668,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_anndata = DummyOperator(task_id="prepare_cwl_sprm_to_anndata")
+    prepare_cwl_sprm_to_anndata = EmptyOperator(task_id="prepare_cwl_sprm_to_anndata")
 
     def build_cwltool_cmd_sprm_to_anndata(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/diagnose_failure.py
+++ b/src/ingest-pipeline/airflow/dags/diagnose_failure.py
@@ -10,7 +10,7 @@ from airflow.exceptions import AirflowException
 
 import utils
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
     )

--- a/src/ingest-pipeline/airflow/dags/export_and_backup.py
+++ b/src/ingest-pipeline/airflow/dags/export_and_backup.py
@@ -13,7 +13,7 @@ from utils import (
     HMDAG,
     encrypt_tok,
     get_queue_resource,
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     pythonop_get_dataset_state,
     encrypt_tok,
 )

--- a/src/ingest-pipeline/airflow/dags/export_and_backup/export_and_backup_plugin.py
+++ b/src/ingest-pipeline/airflow/dags/export_and_backup/export_and_backup_plugin.py
@@ -3,9 +3,6 @@ import inspect
 from pathlib import Path
 from importlib import util
 from typing import Iterator
-import yaml
-
-from utils import localized_assert_json_matches_schema as assert_json_matches_schema
 
 EXPORT_AND_BACKUP_MAP = None
 
@@ -27,25 +24,6 @@ class add_path:
             sys.path.remove(self.path)
         except ValueError:
             pass
-
-
-def _get_export_and_backup_map():
-    """
-    Lazy compilation of export_and_backup map
-    modified from utils._get_workflow_map
-    """
-    if EXPORT_AND_BACKUP_MAP is None:
-        map_path = join(dirname(__file__), EXPORT_AND_BACKUP_MAP)
-        with open(map_path, "r") as f:
-            export_and_backup_map = yaml.safe_load(f)
-        assert_json_matches_schema(export_and_backup_map, "export_and_backup_map_schema.yml")
-        cmp_map = []
-        for dct in export_and_backup_map["export_and_backup_map"]:
-            ct_re = re.compile(dct["collection_type"])
-            at_re = re.compile(dct["assay_type"])
-            cmp_map.append((ct_re, at_re, dct["workflow"]))
-        COMPILED_WORKFLOW_MAP = cmp_map
-    return COMPILED_WORKFLOW_MAP
 
 
 class ExportAndBackupPlugin:

--- a/src/ingest-pipeline/airflow/dags/export_and_backup/plugins/dataset_published.py
+++ b/src/ingest-pipeline/airflow/dags/export_and_backup/plugins/dataset_published.py
@@ -1,13 +1,6 @@
-import traceback
-
-from export_and_backup.export_and_backup_plugin import ExportAndBackupPlugin, add_path
+from export_and_backup.export_and_backup_plugin import ExportAndBackupPlugin
 from status_change.status_utils import get_hubmap_id_from_uuid
 from utils import get_auth_tok
-
-from airflow.configuration import conf as airflow_conf
-
-with add_path(airflow_conf.as_dict()["connections"]["SRC_PATH"].strip("'").strip('"')):
-    from submodules import hubmapinventory
 
 
 class PublishedBackupPlugin(ExportAndBackupPlugin):
@@ -31,23 +24,4 @@ class PublishedExportPlugin(ExportAndBackupPlugin):
         self.token = get_auth_tok(**self.kwargs)
 
     def run_plugin(self):
-        hubmap_id = get_hubmap_id_from_uuid(self.token, self.kwargs["uuid"])["hubmap_id"]
-        dbgap_study_id = self.kwargs.get("dbgap_study_id", None)
-        # instance will need to be changed
-        try:
-            hubmapinventory.inventory.create(
-                hubmap_id,
-                token=self.token,
-                ncores=10,
-                compute_uuids=False,
-                dbgap_study_id=dbgap_study_id,
-                recompute_file_extension=False,
-                backup=False,
-                debug=True,
-            )
-            return "PublishedExportPlugin ran successfully"
-        except Exception as e:
-            formatted_exception = "".join(traceback.TracebackException.from_exception(e).format())
-            return f"PublishedExportPlugin failed! Error: {e}: {formatted_exception}"
-
-    # Need to keep track of failure: is pipeline failure notification sufficient?
+        return "PublishedExportPlugin ran successfully"

--- a/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
+++ b/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
@@ -21,7 +21,7 @@ from hubmap_operators.common_operators import (
 )
 
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     get_tmp_dir_path,
     get_auth_tok,
     get_dataset_uuid,

--- a/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
+++ b/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
@@ -18,7 +18,6 @@ from hubmap_operators.common_operators import (
     LogInfoOperator,
     JoinOperator,
     MoveDataOperator,
-    SetDatasetProcessingOperator,
 )
 
 from utils import (

--- a/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
+++ b/src/ingest-pipeline/airflow/dags/gen_pub_ancillary.py
@@ -132,9 +132,8 @@ with HMDAG(
             print(f"ERROR: {excp}")
             if excp.response.status_code == codes.unauthorized:
                 raise RuntimeError("entity database authorization was rejected?")
-            else:
-                print("benign error")
-                return ""
+            print("benign error")
+            return ""
 
     def build_ancillary_data(**kwargs):
         try:
@@ -161,8 +160,7 @@ with HMDAG(
                     # print(f'md in this vignette: {md_path}')
                     if md_found:
                         raise AssertionError("A vignette has more than one markdown file")
-                    else:
-                        md_found = True
+                    md_found = True
                     vig_fm = frontmatter.loads(md_path.read_text())
                     # print('vig_fm metadata follows')
                     # pprint(vig_fm.metadata)

--- a/src/ingest-pipeline/airflow/dags/geomx.py
+++ b/src/ingest-pipeline/airflow/dags/geomx.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.operators.python import BranchPythonOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.decorators import task
 
 from hubmap_operators.common_operators import (
@@ -12,7 +12,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     CreateTmpDirOperator,
     CleanupTmpDirOperator,
-    SetDatasetProcessingOperator,
     MoveDataOperator,
 )
 
@@ -149,7 +148,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+    prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
     def build_cwltool_cmd2(**kwargs):
         run_id = kwargs["run_id"]
@@ -200,7 +199,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl3 = DummyOperator(task_id="prepare_cwl3")
+    prepare_cwl3 = EmptyOperator(task_id="prepare_cwl3")
 
     def build_cwltool_cmd3(**kwargs):
         run_id = kwargs["run_id"]
@@ -247,7 +246,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl4 = DummyOperator(task_id="prepare_cwl4")
+    prepare_cwl4 = EmptyOperator(task_id="prepare_cwl4")
 
     def build_cwltool_cmd4(**kwargs):
         run_id = kwargs["run_id"]
@@ -295,7 +294,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl5 = DummyOperator(task_id="prepare_cwl5")
+    prepare_cwl5 = EmptyOperator(task_id="prepare_cwl5")
 
     def build_cwltool_cmd5(**kwargs):
         run_id = kwargs["run_id"]
@@ -344,7 +343,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl6 = DummyOperator(task_id="prepare_cwl6")
+    prepare_cwl6 = EmptyOperator(task_id="prepare_cwl6")
 
     def build_cwltool_cmd6(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/kaggle_2_segmentation.py
+++ b/src/ingest-pipeline/airflow/dags/kaggle_2_segmentation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator, BranchPythonOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.decorators import task
 
 import utils
@@ -161,7 +161,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_pyramid = DummyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
+    prepare_cwl_ome_tiff_pyramid = EmptyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
 
     def build_cwltool_cwl_ome_tiff_pyramid_processed(**kwargs):
         run_id = kwargs["run_id"]
@@ -255,7 +255,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_offsets = DummyOperator(task_id="prepare_cwl_ome_tiff_offsets")
+    prepare_cwl_ome_tiff_offsets = EmptyOperator(task_id="prepare_cwl_ome_tiff_offsets")
 
     def build_cwltool_cmd_ome_tiff_offsets(**kwargs):
         run_id = kwargs["run_id"]
@@ -303,7 +303,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_metadata = DummyOperator(task_id="prepare_cwl_ome_tiff_metadata")
+    prepare_cwl_ome_tiff_metadata = EmptyOperator(task_id="prepare_cwl_ome_tiff_metadata")
 
     def build_cwltool_cmd_ome_tiff_metadata(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/launch_checksums.py
+++ b/src/ingest-pipeline/airflow/dags/launch_checksums.py
@@ -19,7 +19,7 @@ from hubmap_operators.common_operators import (
 import utils
 
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
     get_threads_resource,

--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -10,7 +10,7 @@ from hubmap_operators.flex_multi_dag_run import FlexMultiDagRunOperator
 import utils
 
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
     get_preserve_scratch_resource,

--- a/src/ingest-pipeline/airflow/dags/mibi_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/mibi_deepcell.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.decorators import task
 
@@ -165,7 +165,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm = DummyOperator(task_id="prepare_cwl_sprm")
+    prepare_cwl_sprm = EmptyOperator(task_id="prepare_cwl_sprm")
 
     def build_cwltool_cmd_sprm(**kwargs):
         run_id = kwargs["run_id"]
@@ -214,7 +214,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_create_vis_symlink_archive = DummyOperator(
+    prepare_cwl_create_vis_symlink_archive = EmptyOperator(
         task_id="prepare_cwl_create_vis_symlink_archive",
     )
 
@@ -263,7 +263,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_pyramid = DummyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
+    prepare_cwl_ome_tiff_pyramid = EmptyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
 
     def build_cwltool_cwl_ome_tiff_pyramid(**kwargs):
         run_id = kwargs["run_id"]
@@ -314,7 +314,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_offsets = DummyOperator(task_id="prepare_cwl_ome_tiff_offsets")
+    prepare_cwl_ome_tiff_offsets = EmptyOperator(task_id="prepare_cwl_ome_tiff_offsets")
 
     def build_cwltool_cmd_ome_tiff_offsets(**kwargs):
         run_id = kwargs["run_id"]
@@ -362,7 +362,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_json = DummyOperator(task_id="prepare_cwl_sprm_to_json")
+    prepare_cwl_sprm_to_json = EmptyOperator(task_id="prepare_cwl_sprm_to_json")
 
     def build_cwltool_cmd_sprm_to_json(**kwargs):
         run_id = kwargs["run_id"]
@@ -410,7 +410,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_anndata = DummyOperator(task_id="prepare_cwl_sprm_to_anndata")
+    prepare_cwl_sprm_to_anndata = EmptyOperator(task_id="prepare_cwl_sprm_to_anndata")
 
     def build_cwltool_cmd_sprm_to_anndata(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/multiassay_component_metadata.py
+++ b/src/ingest-pipeline/airflow/dags/multiassay_component_metadata.py
@@ -17,7 +17,7 @@ from utils import (
     pythonop_md_consistency_tests,
     make_send_status_msg_function,
     get_tmp_dir_path,
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     pythonop_get_dataset_state,
     encrypt_tok,
 )

--- a/src/ingest-pipeline/airflow/dags/multiome.py
+++ b/src/ingest-pipeline/airflow/dags/multiome.py
@@ -5,7 +5,7 @@ from typing import List
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.decorators import task
 
@@ -121,9 +121,9 @@ def generate_multiome_dag(params: MultiomeSequencingDagParameters) -> DAG:
 
         prepare_cwl1 = prepare_cwl_cmd1()
 
-        prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+        prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
-        prepare_cwl3 = DummyOperator(task_id="prepare_cwl3")
+        prepare_cwl3 = EmptyOperator(task_id="prepare_cwl3")
 
         def build_cwltool_cmd1(**kwargs):
             run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator, BranchPythonOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 # these are the hubmap common operators that are used in all DAGS
 from hubmap_operators.common_operators import (
@@ -11,7 +11,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     CreateTmpDirOperator,
     CleanupTmpDirOperator,
-    SetDatasetProcessingOperator,
     MoveDataOperator,
 )
 
@@ -87,7 +86,7 @@ with HMDAG(
         return inner_build_dataset_name(dag.dag_id, pipeline_name, **kwargs)
 
     # CWL1 - pipeline.cwl
-    prepare_cwl1 = DummyOperator(task_id="prepare_cwl1")
+    prepare_cwl1 = EmptyOperator(task_id="prepare_cwl1")
 
     # print useful info and build command line
     def build_cwltool_cmd1(**kwargs):
@@ -128,7 +127,7 @@ with HMDAG(
     )
 
     # CWL2
-    prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+    prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
     # print useful info and build command line
     def build_cwltool_cmd2(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
+++ b/src/ingest-pipeline/airflow/dags/ometiff_pyramid_ims.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.operators.python import BranchPythonOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 # these are the hubmap common operators that are used in all DAGS
 from hubmap_operators.common_operators import (
@@ -12,7 +12,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     CreateTmpDirOperator,
     CleanupTmpDirOperator,
-    SetDatasetProcessingOperator,
     MoveDataOperator,
 )
 
@@ -89,7 +88,7 @@ with HMDAG(
         return inner_build_dataset_name(dag.dag_id, pipeline_name, **kwargs)
 
     # CWL1 - pipeline.cwl
-    prepare_cwl1 = DummyOperator(task_id="prepare_cwl1")
+    prepare_cwl1 = EmptyOperator(task_id="prepare_cwl1")
 
     # print useful info and build command line
     def build_cwltool_cmd1(**kwargs):
@@ -131,7 +130,7 @@ with HMDAG(
     )
 
     # CWL2
-    prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+    prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
     # print useful info and build command line
     def build_cwltool_cmd2(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
+++ b/src/ingest-pipeline/airflow/dags/pas_ftu_segmentation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator, BranchPythonOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.decorators import task
 
 import utils
@@ -160,7 +160,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_pyramid = DummyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
+    prepare_cwl_ome_tiff_pyramid = EmptyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
 
     def build_cwltool_cwl_ome_tiff_pyramid_processed(**kwargs):
         run_id = kwargs["run_id"]
@@ -254,7 +254,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_offsets = DummyOperator(task_id="prepare_cwl_ome_tiff_offsets")
+    prepare_cwl_ome_tiff_offsets = EmptyOperator(task_id="prepare_cwl_ome_tiff_offsets")
 
     def build_cwltool_cmd_ome_tiff_offsets(**kwargs):
         run_id = kwargs["run_id"]
@@ -302,7 +302,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_metadata = DummyOperator(task_id="prepare_cwl_ome_tiff_metadata")
+    prepare_cwl_ome_tiff_metadata = EmptyOperator(task_id="prepare_cwl_ome_tiff_metadata")
 
     def build_cwltool_cmd_ome_tiff_metadata(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/phenocycler_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/phenocycler_deepcell.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.decorators import task
 
@@ -31,7 +31,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     LogInfoOperator,
     MoveDataOperator,
-    SetDatasetProcessingOperator,
 )
 
 from extra_utils import build_tag_containers
@@ -161,7 +160,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm = DummyOperator(task_id="prepare_cwl_sprm")
+    prepare_cwl_sprm = EmptyOperator(task_id="prepare_cwl_sprm")
 
     def build_cwltool_cmd_sprm(**kwargs):
         run_id = kwargs["run_id"]
@@ -210,7 +209,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_create_vis_symlink_archive = DummyOperator(
+    prepare_cwl_create_vis_symlink_archive = EmptyOperator(
         task_id="prepare_cwl_create_vis_symlink_archive",
     )
 
@@ -259,7 +258,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_pyramid = DummyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
+    prepare_cwl_ome_tiff_pyramid = EmptyOperator(task_id="prepare_cwl_ome_tiff_pyramid")
 
     def build_cwltool_cwl_ome_tiff_pyramid(**kwargs):
         run_id = kwargs["run_id"]
@@ -310,7 +309,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_ome_tiff_offsets = DummyOperator(task_id="prepare_cwl_ome_tiff_offsets")
+    prepare_cwl_ome_tiff_offsets = EmptyOperator(task_id="prepare_cwl_ome_tiff_offsets")
 
     def build_cwltool_cmd_ome_tiff_offsets(**kwargs):
         run_id = kwargs["run_id"]
@@ -358,7 +357,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_json = DummyOperator(task_id="prepare_cwl_sprm_to_json")
+    prepare_cwl_sprm_to_json = EmptyOperator(task_id="prepare_cwl_sprm_to_json")
 
     def build_cwltool_cmd_sprm_to_json(**kwargs):
         run_id = kwargs["run_id"]
@@ -406,7 +405,7 @@ with HMDAG(
         },
     )
 
-    prepare_cwl_sprm_to_anndata = DummyOperator(task_id="prepare_cwl_sprm_to_anndata")
+    prepare_cwl_sprm_to_anndata = EmptyOperator(task_id="prepare_cwl_sprm_to_anndata")
 
     def build_cwltool_cmd_sprm_to_anndata(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/rebuild_primary_dataset_metadata.py
+++ b/src/ingest-pipeline/airflow/dags/rebuild_primary_dataset_metadata.py
@@ -17,7 +17,7 @@ from utils import (
     pythonop_md_consistency_tests,
     make_send_status_msg_function,
     get_tmp_dir_path,
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     pythonop_get_dataset_state,
     encrypt_tok,
 )

--- a/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
+++ b/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
@@ -1,13 +1,4 @@
-import os
-import yaml
-import utils
-from pprint import pprint
-
-from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
 from airflow.operators.empty import EmptyOperator
-from airflow.exceptions import AirflowException
-from airflow.configuration import conf as airflow_conf
 from datetime import datetime, timedelta
 
 from utils import (
@@ -15,17 +6,7 @@ from utils import (
     get_queue_resource,
     get_preserve_scratch_resource,
     create_dataset_state_error_callback,
-    pythonop_md_consistency_tests,
-    make_send_status_msg_function,
     get_tmp_dir_path,
-    localized_assert_json_matches_schema as assert_json_matches_schema,
-    pythonop_get_dataset_state,
-    encrypt_tok,
-)
-
-from hubmap_operators.common_operators import (
-    CreateTmpDirOperator,
-    CleanupTmpDirOperator,
 )
 
 

--- a/src/ingest-pipeline/airflow/dags/reorganize_upload.py
+++ b/src/ingest-pipeline/airflow/dags/reorganize_upload.py
@@ -237,7 +237,7 @@ with HMDAG(
                         f"status of Upload {uuid} is not New, or Submitted, {ds_rslt['status']}"
                     )
 
-                work_dirs.append("'{}'".format(ds_rslt["local_directory_full_path"]))
+                work_dirs.append('"{}"'.format(ds_rslt["local_directory_full_path"]))
             work_dirs = " ".join(work_dirs)
             kwargs["ti"].xcom_push(key="child_work_dirs", value=work_dirs)
             kwargs["ti"].xcom_push(key="child_uuid_list", value=child_uuid_list)

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq.py
@@ -4,7 +4,7 @@ from typing import List
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.decorators import task
 
@@ -107,11 +107,11 @@ def generate_salmon_rnaseq_dag(params: SequencingDagParameters) -> DAG:
 
         prepare_cwl1 = prepare_cwl1_cmd()
 
-        prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+        prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
-        prepare_cwl3 = DummyOperator(task_id="prepare_cwl3")
+        prepare_cwl3 = EmptyOperator(task_id="prepare_cwl3")
 
-        prepare_cwl4 = DummyOperator(task_id="prepare_cwl4")
+        prepare_cwl4 = EmptyOperator(task_id="prepare_cwl4")
 
         def build_cwltool_cmd1(**kwargs):
             run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
+++ b/src/ingest-pipeline/airflow/dags/salmon_rnaseq_bulk.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.operators.python import BranchPythonOperator
-from airflow.operators.dummy import DummyOperator
 from airflow.decorators import task
 
 from hubmap_operators.common_operators import (
@@ -12,7 +11,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     CreateTmpDirOperator,
     CleanupTmpDirOperator,
-    SetDatasetProcessingOperator,
     MoveDataOperator,
 )
 

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
@@ -4,7 +4,7 @@ from typing import List
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.decorators import task
 
@@ -14,7 +14,6 @@ from hubmap_operators.common_operators import (
     JoinOperator,
     LogInfoOperator,
     MoveDataOperator,
-    SetDatasetProcessingOperator,
 )
 
 import utils
@@ -98,7 +97,7 @@ def generate_atac_seq_dag(params: SequencingDagParameters) -> DAG:
 
         prepare_cwl1 = prepare_cwl_cmd1()
 
-        prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+        prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
         def build_cwltool_cmd1(**kwargs):
             run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
+++ b/src/ingest-pipeline/airflow/dags/sc_atac_seq.py
@@ -20,7 +20,6 @@ import utils
 from utils import (
     SequencingDagParameters,
     get_absolute_workflow,
-    get_cwltool_base_cmd,
     get_dataset_uuid,
     get_parent_dataset_uuids_list,
     get_parent_data_dirs_list,

--- a/src/ingest-pipeline/airflow/dags/standardize_extensions.py
+++ b/src/ingest-pipeline/airflow/dags/standardize_extensions.py
@@ -10,7 +10,7 @@ from airflow.exceptions import AirflowException
 
 import utils
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
     )

--- a/src/ingest-pipeline/airflow/dags/status_change/slack_formatter.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack_formatter.py
@@ -77,7 +77,7 @@ def _format_upload_reorganized_datasets(datasets: list[dict], token: str) -> lis
         cleaned_data = []
         for val in data:
             if isinstance(val, list):
-                cleaned_data.append(";".join([x for x in val]))
+                cleaned_data.append(";".join(val))
             elif isinstance(val, str):
                 cleaned_data.append(val.replace(",", ";"))
             else:

--- a/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
@@ -7,7 +7,7 @@ from typing import Any
 from requests import codes
 from requests.exceptions import HTTPError
 
-from airflow.hooks.http_hook import HttpHook
+from airflow.providers.http.hooks.http import HttpHook
 
 
 class EntityUpdateException(Exception):

--- a/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
@@ -102,9 +102,8 @@ def get_submission_context(token: str, uuid: str) -> dict[str, Any]:
         print(f"ERROR: {e}")
         if e.response.status_code == codes.unauthorized:
             raise RuntimeError("entity database authorization was rejected?")
-        else:
-            print("benign error")
-            return {}
+        print("benign error")
+        return {}
 
 
 def get_hubmap_id_from_uuid(token: str, uuid: str) -> str | None:
@@ -128,9 +127,8 @@ def get_hubmap_id_from_uuid(token: str, uuid: str) -> str | None:
         print(f"ERROR: {e}")
         if e.response.status_code == codes.unauthorized:
             raise RuntimeError("entity database authorization was rejected?")
-        else:
-            print("benign error")
-            return None
+        print("benign error")
+        return None
 
 
 def formatted_exception(exception):

--- a/src/ingest-pipeline/airflow/dags/trigger_downstream_processing.py
+++ b/src/ingest-pipeline/airflow/dags/trigger_downstream_processing.py
@@ -9,7 +9,7 @@ from airflow.exceptions import AirflowException
 
 import utils
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
     )

--- a/src/ingest-pipeline/airflow/dags/trigger_file_reindex.py
+++ b/src/ingest-pipeline/airflow/dags/trigger_file_reindex.py
@@ -14,7 +14,6 @@ from utils import (
     HMDAG,
     get_tmp_dir_path,
     get_auth_tok,
-    find_matching_endpoint,
     get_queue_resource,
     get_preserve_scratch_resource,
     )

--- a/src/ingest-pipeline/airflow/dags/trigger_samples_incremental_reindex.py
+++ b/src/ingest-pipeline/airflow/dags/trigger_samples_incremental_reindex.py
@@ -14,7 +14,6 @@ from utils import (
     HMDAG,
     get_tmp_dir_path,
     get_auth_tok,
-    find_matching_endpoint,
     get_queue_resource,
     get_preserve_scratch_resource,
     )

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1921,9 +1921,8 @@ def get_soft_data(dataset_uuid, **kwargs) -> Optional[dict]:
         print(f"ERROR: {e} fetching full path for {dataset_uuid}")
         if e.response.status_code == codes.unauthorized:
             raise RuntimeError("ingest_api_connection authorization was rejected?")
-        else:
-            print("benign error")
-            return None
+        print("benign error")
+        return None
     return response
 
 

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1714,7 +1714,7 @@ def _get_workflow_map() -> List[Tuple[Pattern, Pattern, str]]:
             map = yaml.safe_load(f)
         assert_json_matches_schema(map, WORKFLOW_MAP_SCHEMA)
         cmp_map = []
-        for dct in map_content["workflow_map"]:
+        for dct in map["workflow_map"]:
             ct_re = re.compile(dct["collection_type"])
             at_re = re.compile(dct["assay_type"])
             cmp_map.append((ct_re, at_re, dct["workflow"]))

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -101,7 +101,7 @@ with HMDAG(
     def run_validation(**kwargs):
         lz_path = kwargs["ti"].xcom_pull(key="lz_path")
         uuid = kwargs["ti"].xcom_pull(key="uuid")
-        plugin_path = [path for path in ingest_validation_tests.__path__][0]
+        plugin_path = list(ingest_validation_tests.__path__)[0]
 
         ignore_globs = [uuid, "extras", "*metadata.tsv", "validation_report.txt"]
         app_context = {

--- a/src/ingest-pipeline/airflow/dags/validation_test.py
+++ b/src/ingest-pipeline/airflow/dags/validation_test.py
@@ -10,7 +10,7 @@ from airflow.exceptions import AirflowException
 
 import utils
 from utils import (
-    localized_assert_json_matches_schema as assert_json_matches_schema,
+    assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
     )

--- a/src/ingest-pipeline/airflow/dags/validation_test.py
+++ b/src/ingest-pipeline/airflow/dags/validation_test.py
@@ -103,7 +103,7 @@ with HMDAG('validation_test',
     def run_validation(**kwargs):
         lz_path = kwargs['ti'].xcom_pull(key='lz_path')
         uuid = kwargs['ti'].xcom_pull(key='uuid')
-        plugin_path = [path for path in ingest_validation_tests.__path__][0]
+        plugin_path = list(ingest_validation_tests.__path__)[0]
 
         ignore_globs = [uuid, 'extras', '*metadata.tsv',
                         'validation_report.txt']

--- a/src/ingest-pipeline/airflow/dags/visium.py
+++ b/src/ingest-pipeline/airflow/dags/visium.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.decorators import task
 
@@ -108,13 +108,13 @@ with HMDAG(
 
     prepare_cwl1 = prepare_cwl_cmd1()
 
-    prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+    prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
-    prepare_cwl3 = DummyOperator(task_id="prepare_cwl3")
+    prepare_cwl3 = EmptyOperator(task_id="prepare_cwl3")
 
-    prepare_cwl4 = DummyOperator(task_id="prepare_cwl4")
+    prepare_cwl4 = EmptyOperator(task_id="prepare_cwl4")
 
-    prepare_cwl5 = DummyOperator(task_id="prepare_cwl5")
+    prepare_cwl5 = EmptyOperator(task_id="prepare_cwl5")
 
     def build_cwltool_cmd1(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/dags/visium_probes.py
+++ b/src/ingest-pipeline/airflow/dags/visium_probes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.decorators import task
 
@@ -110,13 +110,13 @@ with HMDAG(
 
     prepare_cwl1 = prepare_cwl_cmd1()
 
-    prepare_cwl2 = DummyOperator(task_id="prepare_cwl2")
+    prepare_cwl2 = EmptyOperator(task_id="prepare_cwl2")
 
-    prepare_cwl3 = DummyOperator(task_id="prepare_cwl3")
+    prepare_cwl3 = EmptyOperator(task_id="prepare_cwl3")
 
-    prepare_cwl4 = DummyOperator(task_id="prepare_cwl4")
+    prepare_cwl4 = EmptyOperator(task_id="prepare_cwl4")
 
-    prepare_cwl5 = DummyOperator(task_id="prepare_cwl5")
+    prepare_cwl5 = EmptyOperator(task_id="prepare_cwl5")
 
     def build_cwltool_cmd1(**kwargs):
         run_id = kwargs["run_id"]

--- a/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
+++ b/src/ingest-pipeline/airflow/plugins/hubmap_operators/common_operators.py
@@ -1,14 +1,8 @@
 #! /usr/bin/env python
 
-# from pprint import pprint
-
-# from airflow.operators.bash_operator import BashOperator
 from airflow.operators.bash import BashOperator
-# from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.dummy import DummyOperator
-# from airflow.operators.python_operator import PythonOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
-# from airflow.utils.decorators import apply_defaults
 
 from utils import (
     get_dataset_uuid,
@@ -25,9 +19,9 @@ class LogInfoOperator(PythonOperator):
         super().__init__(python_callable=pythonop_trigger_target,
                          provide_context=True,
                          **kwargs)
-    
 
-class JoinOperator(DummyOperator):
+
+class JoinOperator(EmptyOperator):
     # @apply_defaults
     def __init__(self, **kwargs):
         if "trigger_rule" in kwargs:
@@ -76,13 +70,13 @@ class CleanupTmpDirOperator(BashOperator):
 class SetDatasetProcessingOperator(PythonOperator):
     # @apply_defaults
     def __init__(self, **kwargs):
-        super().__init__(python_callable=pythonop_set_dataset_state, 
+        super().__init__(python_callable=pythonop_set_dataset_state,
                          provide_context=True,
                          op_kwargs={
                              'dataset_uuid_callable': get_dataset_uuid,
                          },
                          **kwargs)
-    
+
 
 class MoveDataOperator(BashOperator):
     # @apply_defaults

--- a/src/ingest-pipeline/md/data_file_types/csv_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/csv_metadata_file.py
@@ -8,12 +8,12 @@ class CSVMetadataFile(MetadataFile):
     """
     A metadata file type for csv files.  At the moment we are keeping it maximally dumb.
     """
-    category_name = 'CSV';
+    category_name = 'CSV'
 
     def collect_metadata(self):
         print('parsing csv from %s' % self.path)
         md = []
-        with open(self.path, 'rU', newline='') as f:
+        with open(self.path, 'r', newline='') as f:
             dialect = csv.Sniffer().sniff(f.read(256))
             f.seek(0)
             reader = csv.DictReader(f, dialect=dialect)

--- a/src/ingest-pipeline/md/data_file_types/false_json_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/false_json_metadata_file.py
@@ -5,10 +5,10 @@ import json
 
 class FalseJSONMetadataFile(MetadataFile):
     """A metadata file type for files that claim to be JSON files but aren't """
-    category_name = 'FALSE_JSON';
+    category_name = 'FALSE_JSON'
 
     def collect_metadata(self):
         print('not parsing json from %s' % self.path)
-        with open(self.path, 'rU') as f:
+        with open(self.path, 'r') as f:
             md = {}
         return md

--- a/src/ingest-pipeline/md/data_file_types/json_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/json_metadata_file.py
@@ -5,10 +5,10 @@ import json
 
 class JSONMetadataFile(MetadataFile):
     """A metadata file type for JSON files"""
-    category_name = 'JSON';
+    category_name = 'JSON'
 
     def collect_metadata(self):
         print('parsing json from %s' % self.path)
-        with open(self.path, 'rU') as f:
+        with open(self.path, 'r') as f:
             md = json.load(f)
         return md

--- a/src/ingest-pipeline/md/data_file_types/mtx_tform_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/mtx_tform_metadata_file.py
@@ -11,7 +11,7 @@ class MtxTformMetadataFile(MetadataFile):
         print('parsing transformation text from %s' % self.path)
         rslt = {}
         row_list = []
-        with open(self.path, 'rU') as f:
+        with open(self.path, 'r') as f:
             for line in f:
                 line = line.strip()
                 words = line.split()

--- a/src/ingest-pipeline/md/data_file_types/tsv_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/tsv_metadata_file.py
@@ -9,16 +9,16 @@ class TSVMetadataFile(MetadataFile):
     """
     A metadata file type specialized for tsv files, since the csv sniffer often fails
     """
-    category_name = 'TSV';
+    category_name = 'TSV'
 
     def collect_metadata(self):
         print('parsing tsv from %s' % self.path)
         md = []
         try:
-            with open(self.path, 'rU', newline='', encoding='ascii') as f:
+            with open(self.path, 'r', newline='', encoding='ascii') as f:
                 reader = csv.DictReader(f, delimiter='\t')
                 for row in reader:
-                    md.append({k : v for k, v in row.items()})
+                    md.append({k: v for k, v in row.items()})
         except UnicodeDecodeError as e:
             raise MetadataError(str(e) + f'in {self.path}')
 

--- a/src/ingest-pipeline/md/data_file_types/txt_tform_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/txt_tform_metadata_file.py
@@ -4,12 +4,12 @@ from metadata_file import MetadataFile
 
 class TxtTformMetadataFile(MetadataFile):
     """A metadata file type for files containing geometrical transforms as text"""
-    category_name = 'TxtTform';
+    category_name = 'TxtTform'
 
     def collect_metadata(self):
         print('parsing transformation text from %s' % self.path)
         rslt = {}
-        with open(self.path, 'rU') as f:
+        with open(self.path, 'r') as f:
             for line in f:
                 line = line.strip()
                 assert line[0] == '(' and line[-1] == ')', "Missing parens line <{}>".format(line)

--- a/src/ingest-pipeline/md/data_file_types/txt_wordlist_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/txt_wordlist_metadata_file.py
@@ -4,12 +4,12 @@ from metadata_file import MetadataFile
 
 class TxtWordListMetadataFile(MetadataFile):
     """A metadata file type containing text to be returned as a list of words"""
-    category_name = 'TxtWordList';
+    category_name = 'TxtWordList'
 
     def collect_metadata(self):
         print('collecting words from %s' % self.path)
         rslt_l = []
-        with open(self.path, 'rU') as f:
+        with open(self.path, 'r') as f:
             for line in f:
                 line = line.strip()
                 words = line.split()

--- a/src/ingest-pipeline/md/data_file_types/yaml_metadata_file.py
+++ b/src/ingest-pipeline/md/data_file_types/yaml_metadata_file.py
@@ -5,10 +5,10 @@ import yaml
 
 class YamlMetadataFile(MetadataFile):
     """A metadata file type for yaml files"""
-    category_name = 'Yaml';
+    category_name = 'Yaml'
 
     def collect_metadata(self):
         print('parsing yaml from %s' % self.path)
-        with open(self.path, 'rU') as f:
+        with open(self.path, 'r') as f:
             md = yaml.safe_load(f)
         return md

--- a/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
+++ b/src/ingest-pipeline/misc/tools/airflow_wrapper.sh
@@ -96,4 +96,5 @@ printenv
 
 cd $AIRFLOW_HOME ; \
 env AIRFLOW__HUBMAP_API_PLUGIN__BUILD_NUMBER="$(cat ${top_level_dir}/build_number)" \
+    AIRFLOW__WEBSERVER__SHOW_TRIGGER_FORM_IF_NO_PARAMS="True" \
     airflow $*

--- a/src/ingest-pipeline/misc/tools/new_upload_survey.py
+++ b/src/ingest-pipeline/misc/tools/new_upload_survey.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import argparse
-import numpy as np
 import pandas as pd
 
 from survey import (EntityFactory,
@@ -36,7 +35,7 @@ def main():
         if 'note' in in_df.columns:
             # re-read with better handling for the note string
             in_df = pd.read_csv(args.uuid_txt, engine="python", sep=None,
-                                dtype={'note': np.str}, encoding='utf-8-sig')
+                                dtype={'note': str}, encoding='utf-8-sig')
         if 'uuid' in in_df.columns:
             uuid_key = 'uuid'
         elif 'e.uuid' in in_df.columns:
@@ -127,7 +126,7 @@ def main():
 
     for notes_file in args.notes or []:
         notes_df = pd.read_csv(notes_file, engine='python', sep=None,
-                               dtype={'note': np.str}, encoding='utf-8-sig')
+                               dtype={'note': str}, encoding='utf-8-sig')
         for elt in ['uuid', 'note']:
             if not elt in notes_df.columns:
                 print(f'ERROR: notes file does not contain {elt}, so notes were not merged')

--- a/src/ingest-pipeline/misc/tools/schema_tester.py
+++ b/src/ingest-pipeline/misc/tools/schema_tester.py
@@ -7,8 +7,7 @@
 import sys
 from os import walk
 from os.path import (
-    basename, dirname, relpath, split, join, getsize,
-    realpath, exists, isdir
+    dirname, join, realpath, isdir
 )
 import optparse
 import yaml
@@ -68,7 +67,7 @@ def main(myargv=None):
         schema_fname = args[0]
 
         if opts.R and isdir(args[1]):
-            for root, dirs, files in walk(args[1]):  # @UnusedVariable
+            for root, _, files in walk(args[1]):
                 for fName in files:
                     if fName.lower().endswith(('.yaml', '.yml', '.json', '.jsn')):
                         path = join(root, fName)

--- a/src/ingest-pipeline/misc/tools/split_and_create.py
+++ b/src/ingest-pipeline/misc/tools/split_and_create.py
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import math
 import re
 import time
 from pathlib import Path
@@ -14,7 +13,7 @@ import pandas as pd
 from extra_utils import SoftAssayClient
 from status_change.status_manager import StatusChanger, Statuses
 
-from airflow.hooks.http_hook import HttpHook
+from airflow.providers.http.hooks.http import HttpHook
 
 # There has got to be a better solution for this, but I can't find it
 try:

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -1,5 +1,6 @@
-# We need the dependencies of ingest-validation tools, but relative paths don't work
+# Install dependencies of submodules
 # -r ${CWD}/submodules/ingest-validation-tools/requirements.txt
+# -r ${CWD}/submodules/ingest-validation-tests/requirements.txt
 apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.10.5
 git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
 git+https://github.com/hubmapconsortium/fastq-utils@v0.2.5#egg=hubmap-fastq-utils

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -1,50 +1,52 @@
-# git+https://github.com/hubmapconsortium/commons@main#egg=hubmap-commons==2.0.11
-jsonref>=0.2,<1.0
-hubmap-commons==2.1.3
-prov==1.5.1
-# pylibczi>=1.1.1
-# tifffile==2020.12.8
-tifffile==2021.11.2
-xmltodict==0.13.0
-pyimzml==1.5.2
-apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.5.3
-airflow-multi-dagrun==2.3.1
-jsonschema==4.0.0
-fastjsonschema==2.16.2
-requests==2.27.1
-jsonref-ap==0.3.dev0
-PyYAML==6.0
-rdflib==5.0.0
-rdflib-jsonld==0.6.2
-Flask-OAuthlib==0.9.6
-psycopg2-binary==2.9.5
-# dataclasses==0.8
-git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
-git+https://github.com/hubmapconsortium/fastq-utils@v0.2.5#egg=hubmap-fastq-utils
 # We need the dependencies of ingest-validation tools, but relative paths don't work
 # -r ${CWD}/submodules/ingest-validation-tools/requirements.txt
-tableschema==1.20.2
-goodtables==2.5.4
-globus-cli==3.10.1
-yattag==1.14.0
-frictionless==4.0.0
-sqlalchemy==1.4.15
-xmlschema==1.9.2
-WTForms==2.3.3
-hubmap_sdk==1.0.2
-pandas==1.2.0
-authlib==0.15.6
-google-api-python-client==2.52.0
-google-auth-httplib2==0.1.0
-google-auth-oauthlib==0.8.0
-python-magic==0.4.27
-numpyencoder==0.3.0
-tqdm==4.36.1
-pandarallel==1.6.4
-python-frontmatter>=1.0.0
-imagecodecs>=2023.3.16
-pendulum==2.1.2
-Flask-Session==0.5.0
-multi-docker-build==0.7.3
+apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.5.3
+git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
+git+https://github.com/hubmapconsortium/fastq-utils@v0.2.5#egg=hubmap-fastq-utils
+globus-sdk==3.56.1
+google-api-python-client==2.171.0
+google-auth-httplib2==0.2.0
+google-auth-oauthlib==1.2.2
+hubmap-commons==2.1.19
 hubmap-pipeline-release-mgmt==0.6.2
-xmlsec==1.3.14
+hubmap_sdk==1.0.10
+jsonschema==4.23.0
+multi-docker-build==0.7.3
+pandas==2.2.2
+pyimzml==1.5.2
+python-frontmatter==1.1.0
+PyYAML==6.0.2
+requests==2.32.3
+sqlalchemy==1.4.15
+tifffile==2024.6.18
+xmltodict==0.13.0
+
+# removed: not used, no deps; only submodule deps; deps from other
+# installed packages, will re-evaluate if there are conflicts
+# airflow-multi-dagrun==2.3.1
+# authlib==0.15.6
+# Flask-OAuthlib==0.9.6 # deprecated, use authlib instead
+# Flask-Session==0.5.0
+# fastjsonschema==2.16.1
+# frictionless==4.0.0 # IVT only
+# globus-cli==3.34.0
+# goodtables==2.5.4
+# hubmap-pipeline-release-mgmt==0.6.2
+# imagecodecs>=2023.3.16 # IVT only
+# jsonref-ap==0.3.dev0
+# jsonref>=0.2,<1.0
+# multi-docker-build==0.7.3
+# numpyencoder==0.3.0
+# pandarallel==1.6.4 # hubmap-inventory
+# pendulum==2.1.2
+# prov==1.5.1
+# psycopg2-binary==2.9.5
+# python-magic==0.4.27 # hubmap-inventory
+# rdflib==5.0.0
+# rdflib-jsonld==0.6.2
+# tableschema==1.20.2 # IVT only
+# tqdm==4.36.1
+# WTForms==2.3.3
+# xmlschema==3.4.5 # xmlschema==1.9.2 # IVT only
+# xmlsec==1.3.14
+# yattag==1.14.0

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -20,7 +20,7 @@ python-frontmatter==1.1.0
 PyYAML==6.0.2
 requests==2.32.3
 sqlalchemy==1.4.54
-tifffile==2024.6.18
+tifffile==2021.11.2
 xmlsec==1.3.14
 xmltodict==0.13.0
 authlib==1.6.0

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -1,6 +1,6 @@
 # We need the dependencies of ingest-validation tools, but relative paths don't work
 # -r ${CWD}/submodules/ingest-validation-tools/requirements.txt
-apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.5.3
+apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.10.5
 git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
 git+https://github.com/hubmapconsortium/fastq-utils@v0.2.5#egg=hubmap-fastq-utils
 globus-sdk==3.56.1

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -22,6 +22,7 @@ sqlalchemy==1.4.54
 tifffile==2024.6.18
 xmlsec==1.3.14
 xmltodict==0.13.0
+authlib==1.6.0
 
 # removed: not used, no deps; only submodule deps; deps from other
 # installed packages, will re-evaluate if there are conflicts

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -1,7 +1,7 @@
 # Install dependencies of submodules
 # -r ${CWD}/submodules/ingest-validation-tools/requirements.txt
 # -r ${CWD}/submodules/ingest-validation-tests/requirements.txt
-apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.10.5
+apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.11.0 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.11.txt"
 git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
 git+https://github.com/hubmapconsortium/fastq-utils@v0.2.5#egg=hubmap-fastq-utils
 globus-sdk==3.56.1
@@ -18,8 +18,9 @@ pyimzml==1.5.2
 python-frontmatter==1.1.0
 PyYAML==6.0.2
 requests==2.32.3
-sqlalchemy==1.4.15
+sqlalchemy==1.4.54
 tifffile==2024.6.18
+xmlsec==1.3.14
 xmltodict==0.13.0
 
 # removed: not used, no deps; only submodule deps; deps from other
@@ -49,5 +50,4 @@ xmltodict==0.13.0
 # tqdm==4.36.1
 # WTForms==2.3.3
 # xmlschema==3.4.5 # xmlschema==1.9.2 # IVT only
-# xmlsec==1.3.14
 # yattag==1.14.0

--- a/src/ingest-pipeline/requirements.txt
+++ b/src/ingest-pipeline/requirements.txt
@@ -2,6 +2,7 @@
 # -r ${CWD}/submodules/ingest-validation-tools/requirements.txt
 # -r ${CWD}/submodules/ingest-validation-tests/requirements.txt
 apache-airflow[celery,crypto,postgres,redis,ssh,amazon]==2.11.0 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.11.txt"
+airflow-multi-dagrun==2.3.1
 git+https://github.com/hubmapconsortium/cwltool.git@docker-gpu#egg=cwltool
 git+https://github.com/hubmapconsortium/fastq-utils@v0.2.5#egg=hubmap-fastq-utils
 globus-sdk==3.56.1

--- a/src/ingest-pipeline/submodules/__init__.py
+++ b/src/ingest-pipeline/submodules/__init__.py
@@ -4,7 +4,6 @@ from importlib import import_module
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "ingest-validation-tools", "src"))
 sys.path.append(os.path.join(os.path.dirname(__file__), "ingest-validation-tests", "src"))
-sys.path.append(os.path.join(os.path.dirname(__file__), "hubmap-inventory"))
 
 ingest_validation_tools_upload = import_module("ingest_validation_tools.upload")
 ingest_validation_tools_error_report = import_module("ingest_validation_tools.error_report")
@@ -15,7 +14,6 @@ ingest_validation_tools_plugin_validator = import_module(
     "ingest_validation_tools.plugin_validator"
 )
 ingest_validation_tests = import_module("ingest_validation_tests")
-hubmapinventory = import_module("hubmapinventory")
 
 __all__ = [
     "ingest_validation_tools_validation_utils",
@@ -23,9 +21,7 @@ __all__ = [
     "ingest_validation_tools_error_report",
     "ingest_validation_tools_plugin_validator",
     "ingest_validation_tests",
-    "hubmapinventory",
 ]
 
-sys.path.pop()
 sys.path.pop()
 sys.path.pop()

--- a/src/ingest-pipeline/submodules/__init__.py
+++ b/src/ingest-pipeline/submodules/__init__.py
@@ -1,116 +1,31 @@
-import sys
 import os
+import sys
 from importlib import import_module
 
-sys.path.append(os.path.join(os.path.dirname(__file__),
-                             'ingest-validation-tools', 'src'))
-sys.path.append(os.path.join(os.path.dirname(__file__),
-                             'ingest-validation-tests', 'src'))
-sys.path.append(os.path.join(os.path.dirname(__file__),
-                             'py-hubmapbags'))
-sys.path.append(os.path.join(os.path.dirname(__file__),
-                             'hubmap-inventory'))
+sys.path.append(os.path.join(os.path.dirname(__file__), "ingest-validation-tools", "src"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "ingest-validation-tests", "src"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "hubmap-inventory"))
 
-ingest_validation_tools_upload = import_module('ingest_validation_tools.upload')
-ingest_validation_tools_error_report = import_module('ingest_validation_tools.error_report')
-ingest_validation_tools_validation_utils = import_module('ingest_validation_tools.validation_utils')
-ingest_validation_tools_plugin_validator = import_module('ingest_validation_tools.plugin_validator')
-ingest_validation_tests = import_module('ingest_validation_tests')
-hubmapbags = import_module('hubmapbags')
-hubmapbags_anatomy = import_module('hubmapbags.anatomy')
-hubmapbags_apis = import_module('hubmapbags.apis')
-hubmapbags_assay_type = import_module('hubmapbags.assay_type')
-hubmapbags_biosample = import_module('hubmapbags.biosample')
-hubmapbags_biosample_disease = import_module('hubmapbags.biosample_disease')
-hubmapbags_biosample_from_subject = import_module('hubmapbags.biosample_from_subject')
-hubmapbags_biosample_gene = import_module('hubmapbags.biosample_gene')
-hubmapbags_biosample_in_collection = import_module('hubmapbags.biosample_in_collection')
-hubmapbags_biosample_substance = import_module('hubmapbags.biosample_substance')
-hubmapbags_collection = import_module('hubmapbags.collection')
-hubmapbags_collection_anatomy = import_module('hubmapbags.collection_anatomy')
-hubmapbags_collection_compound = import_module('hubmapbags.collection_compound')
-hubmapbags_collection_defined_by_project = import_module('hubmapbags.collection_defined_by_project')
-hubmapbags_collection_disease = import_module('hubmapbags.collection_disease')
-hubmapbags_collection_gene = import_module('hubmapbags.collection_gene')
-hubmapbags_collection_in_collection = import_module('hubmapbags.collection_in_collection')
-hubmapbags_collection_phenotype = import_module('hubmapbags.collection_phenotype')
-hubmapbags_collection_protein = import_module('hubmapbags.collection_protein')
-hubmapbags_collection_substance = import_module('hubmapbags.collection_substance')
-hubmapbags_collection_taxonomy = import_module('hubmapbags.collection_taxonomy')
-hubmapbags_file = import_module('hubmapbags.file')
-hubmapbags_file_describes_biosample = import_module('hubmapbags.file_describes_biosample')
-hubmapbags_file_describes_collection = import_module('hubmapbags.file_describes_collection')
-hubmapbags_file_describes_subject = import_module('hubmapbags.file_describes_subject')
-hubmapbags_file_format = import_module('hubmapbags.file_format')
-hubmapbags_file_in_collection = import_module('hubmapbags.file_in_collection')
-hubmapbags_id_namespace = import_module('hubmapbags.id_namespace')
-hubmapbags_magic = import_module('hubmapbags.magic')
-hubmapbags_ncbi_taxonomy = import_module('hubmapbags.ncbi_taxonomy')
-hubmapbags_primary_dcc_contact = import_module('hubmapbags.primary_dcc_contact')
-hubmapbags_project_in_project = import_module('hubmapbags.project_in_project')
-hubmapbags_projects = import_module('hubmapbags.projects')
-hubmapbags_subject = import_module('hubmapbags.subject')
-hubmapbags_subject_disease = import_module('hubmapbags.subject_disease')
-hubmapbags_subject_in_collection = import_module('hubmapbags.subject_in_collection')
-hubmapbags_subject_phenotype = import_module('hubmapbags.subject_phenotype')
-hubmapbags_subject_race = import_module('hubmapbags.subject_race')
-hubmapbags_subject_role_taxonomy = import_module('hubmapbags.subject_role_taxonomy')
-hubmapbags_subject_substance = import_module('hubmapbags.subject_substance')
-hubmapbags_utilities = import_module('hubmapbags.utilities')
-hubmapbags_uuids = import_module('hubmapbags.uuids')
-hubmapinventory = import_module('hubmapinventory')
+ingest_validation_tools_upload = import_module("ingest_validation_tools.upload")
+ingest_validation_tools_error_report = import_module("ingest_validation_tools.error_report")
+ingest_validation_tools_validation_utils = import_module(
+    "ingest_validation_tools.validation_utils"
+)
+ingest_validation_tools_plugin_validator = import_module(
+    "ingest_validation_tools.plugin_validator"
+)
+ingest_validation_tests = import_module("ingest_validation_tests")
+hubmapinventory = import_module("hubmapinventory")
 
-__all__ = ["ingest_validation_tools_validation_utils",
-           "ingest_validation_tools_upload",
-           "ingest_validation_tools_error_report",
-           "ingest_validation_tools_plugin_validator",
-           "ingest_validation_tests",
-           "hubmapbags",
-           "hubmapbags_anatomy",
-           "hubmapbags_apis",
-           "hubmapbags_assay_type",
-           "hubmapbags_biosample",
-           "hubmapbags_biosample_disease",
-           "hubmapbags_biosample_from_subject",
-           "hubmapbags_biosample_gene",
-           "hubmapbags_biosample_in_collection",
-           "hubmapbags_biosample_substance",
-           "hubmapbags_collection",
-           "hubmapbags_collection_anatomy",
-           "hubmapbags_collection_compound",
-           "hubmapbags_collection_defined_by_project",
-           "hubmapbags_collection_disease",
-           "hubmapbags_collection_gene",
-           "hubmapbags_collection_in_collection",
-           "hubmapbags_collection_phenotype",
-           "hubmapbags_collection_protein",
-           "hubmapbags_collection_substance",
-           "hubmapbags_collection_taxonomy",
-           "hubmapbags_file",
-           "hubmapbags_file_describes_biosample",
-           "hubmapbags_file_describes_collection",
-           "hubmapbags_file_describes_subject",
-           "hubmapbags_file_format",
-           "hubmapbags_file_in_collection",
-           "hubmapbags_id_namespace",
-           "hubmapbags_magic",
-           "hubmapbags_ncbi_taxonomy",
-           "hubmapbags_primary_dcc_contact",
-           "hubmapbags_project_in_project",
-           "hubmapbags_projects",
-           "hubmapbags_subject",
-           "hubmapbags_subject_disease",
-           "hubmapbags_subject_in_collection",
-           "hubmapbags_subject_phenotype",
-           "hubmapbags_subject_race",
-           "hubmapbags_subject_role_taxonomy",
-           "hubmapbags_subject_substance",
-           "hubmapbags_utilities",
-           "hubmapbags_uuids",
-           "hubmapinventory",
-           ]
+__all__ = [
+    "ingest_validation_tools_validation_utils",
+    "ingest_validation_tools_upload",
+    "ingest_validation_tools_error_report",
+    "ingest_validation_tools_plugin_validator",
+    "ingest_validation_tests",
+    "hubmapinventory",
+]
 
-sys.path.pop()
 sys.path.pop()
 sys.path.pop()
 sys.path.pop()


### PR DESCRIPTION
Status: needs testing, need to figure out `HUBMAP_PYTHON_VERSION` / conda environment piece.

- Required packages upgraded to ensure compatibility with Python 3.11 upgrade.
     - Pruned `requirements.txt`, may need to re-add things, or else remove commented lines.
- Associated PR to config repo to update `airflow.cfg` value that changed between Airflow versions.
- Replaced deprecated references to `http_hook` and `DummyOperator`.
- Minor style updates.

Submodules
- Is submodule `py-hubmapbags` necessary?
- Submodule `hubmap-inventory` has either been deleted or I've lost access to it. Regardless, it was only used by `export_and_backup` functionality which is....also not used.
     - Should `export_and_backup` be removed?
- Assuming CWL requirements are handled by containers.
- Added `ingest-validation-tests` requirements installation to `requirements.txt`.

Other
- Deployment on DEV has been blocked by an issue connecting to postgres. Still troubleshooting.
- Deployment could use some newer documentation, potential updates to/comments in example `.service` files, removal of deprecated scripts (e.g., I think, `regenerate_venv.sh`).
- Need to make sure GH Actions succeed once #1070 is merged.