### PR TITLE
Welling/status changer refactor

### DIFF
--- a/src/ingest-pipeline/airflow/dags/schema_utils.py
+++ b/src/ingest-pipeline/airflow/dags/schema_utils.py
@@ -1,0 +1,22 @@
+from typing import Union, Dict, List, Any
+from os.path import join, dirname, realpath
+from hubmap_commons.schema_tools import assert_json_matches_schema, set_schema_base_path
+
+JSONType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
+
+SCHEMA_BASE_PATH = join(dirname(dirname(dirname(realpath(__file__)))), "schemata")
+SCHEMA_BASE_URI = "http://schemata.hubmapconsortium.org/"
+
+set_schema_base_path(SCHEMA_BASE_PATH, SCHEMA_BASE_URI)
+
+def localized_assert_json_matches_schema(jsn: JSONType, schemafile: str) -> None:
+    """
+    This version of assert_json_matches_schema knows where to find schemata used by this module
+    """
+    try:
+        return assert_json_matches_schema(jsn, schemafile)  # localized by set_schema_base_path
+    except AssertionError as e:
+        print("ASSERTION FAILED: {}".format(e))
+        raise
+
+

--- a/src/ingest-pipeline/airflow/dags/schema_utils.py
+++ b/src/ingest-pipeline/airflow/dags/schema_utils.py
@@ -9,7 +9,7 @@ SCHEMA_BASE_URI = "http://schemata.hubmapconsortium.org/"
 
 set_schema_base_path(SCHEMA_BASE_PATH, SCHEMA_BASE_URI)
 
-def localized_assert_json_matches_schema(jsn: JSONType, schemafile: str) -> None:
+def localized_assert_json_matches_schema(jsn: JSONType, schemafile: str) -> True:
     """
     This version of assert_json_matches_schema knows where to find schemata used by this module
     """

--- a/src/ingest-pipeline/airflow/dags/status_change/failure_callback.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/failure_callback.py
@@ -1,5 +1,5 @@
 import logging
-from pprint import pprint
+from pprint import pformat
 
 from status_change.status_manager import StatusChanger
 from status_change.status_utils import formatted_exception
@@ -15,17 +15,8 @@ class FailureCallback:
     List should be overridden by each subclass with appropriate values.
     """
 
-    def __init__(self, context):
-        self.context = context
-        self.uuid = self.context.get("task_instance").xcom_pull(key="uuid")
-        self.context["uuid"] = self.uuid
-        self.auth_tok = get_auth_tok(**context)
-        self.dag_run = self.context.get("dag_run")
-        self.task = self.context.get("task")
-        exception = self.context.get("exception")
-        self.formatted_exception = formatted_exception(exception)
-
-        self.pre_set_status()
+    def __init__(self, module_name):
+        self.called_from = module_name
 
     def get_extra_fields(self):
         """
@@ -36,16 +27,10 @@ class FailureCallback:
         return {
             "validation_message": f"""
                 Process {self.dag_run.dag_id} started {self.dag_run.execution_date}
-                failed at task {self.task.task_id}.
+                failed at task {self.task.task_id} in {self.called_from}.
                 {f'Error: {self.formatted_exception}' if self.formatted_exception else ""}
             """,
         }
-
-    def pre_set_status(self):
-        # Allows for alterations to props, before calling StatusChanger
-        # This was added to support some email functions and is perhaps
-        # at the moment over-engineered.
-        self.set_status()
 
     def set_status(self):
         """
@@ -53,11 +38,25 @@ class FailureCallback:
         otherwise it will remain in the "Processing" state
         """
         data = self.get_extra_fields()
-        logging.info("data: ")
-        logging.info(pprint(data))
+        logging.info("data:\n" + pformat(data))
         StatusChanger(
             self.uuid,
             self.auth_tok,
             status="error",
             fields_to_overwrite=data,
         ).update()
+
+    def __call__(self, context):
+        """
+        This happens when the DAG to which the instance is attached actually
+        encounters an error.
+        """
+        self.uuid = context.get("task_instance").xcom_pull(key="uuid")
+        context["uuid"] = self.uuid
+        self.auth_tok = get_auth_tok(**context)
+        self.dag_run = context.get("dag_run")
+        self.task = context.get("task")
+        exception = context.get("exception")
+        self.formatted_exception = formatted_exception(exception)
+
+        self.set_status()

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -145,9 +145,19 @@ class EntityUpdater:
             {self.fields_to_change}
             """
         )
+        original_entity_type = self.entity_data.get("entity_type")
         updated_entity_data = self.entity_data.copy()
         updated_entity_data.update(self.fields_to_change)
-        assert_json_matches_schema(updated_entity_data, "entity_metadata_schema.yml")
+        updated_entity_type = updated_entity_data.get("entity_type")
+        if original_entity_type != updated_entity_type:
+            raise EntityUpdateException(
+                "An EntityUpdater or StatusChanger cannot change the entity_type"
+                f" (attempted change from {original_entity_type} to {updated_entity_type})"
+            )
+        try:
+            assert_json_matches_schema(updated_entity_data, "entity_metadata_schema.yml")
+        except AssertionError as excp:
+            raise EntityUpdateException(excp) from excp
         if self.verbose:
             logging.info(f"Updating {self.uuid} with data {self.fields_to_change}...")
         try:

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -4,7 +4,6 @@ import json
 import logging
 from functools import cached_property
 from typing import Literal, Optional, Union, Any
-from os.path import join, dirname, realpath
 
 from airflow.providers.http.hooks.http import HttpHook
 
@@ -45,7 +44,7 @@ class StatusChangeAction:
 class CheckPriorityReorgSCA(StatusChangeAction):
 
     def test(self, context):
-        return context.get("priority_project_list")
+        return bool(context.get("priority_project_list"))
 
     def run(self, context):
         msg, channel = format_priority_reorganized_msg(self.token, self.uuid)

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -4,6 +4,7 @@ import json
 import logging
 from functools import cached_property
 from typing import Literal, Optional, Union
+from os.path import join, dirname, realpath
 
 from airflow.providers.http.hooks.http import HttpHook
 
@@ -15,7 +16,124 @@ from .status_utils import (
     get_submission_context,
 )
 
+from schema_utils import (
+    localized_assert_json_matches_schema as assert_json_matches_schema
+)
 
+ENTITY_JSON_SCHEMA = "entity_metadata_schema.yml"  # from this repo's schemata directory
+
+
+# class StatusChangeAction:
+#     def __init__(self, callback):
+#         self.callback = callback
+
+#     def run(self, **kwargs):
+#         self.callback(**kwargs)
+
+
+# STATUS_CHANGE_TRIGGER_TBL = {
+#     ("*", "error"): [StatusChangeAction(send_email)]
+# }
+
+
+# class EntityUpdater:
+#     def __init__(
+#         self,
+#         uuid: str,
+#         token: str,
+#         http_conn_id: str = "entity_api_connection",
+#         fields_to_overwrite: Optional[dict] = None,
+#         fields_to_append_to: Optional[dict] = None,
+#         delimiter: str = "|",
+#         extra_options: Optional[dict] = None,
+#         verbose: bool = True,
+#     ):
+#         self.uuid = uuid
+#         self.token = token
+#         self.http_conn_id = http_conn_id
+#         self.fields_to_overwrite = fields_to_overwrite if fields_to_overwrite else {}
+#         self.fields_to_append_to = fields_to_append_to if fields_to_append_to else {}
+#         self.delimiter = delimiter
+#         self.extra_options = extra_options if extra_options else {}
+#         self.verbose = verbose
+#         self.entity_type = self.get_entity_type()
+
+#     @cached_property
+#     def entity_data(self):
+#         rslt = get_submission_context(self.token, self.uuid)
+#         from pprint import pprint
+#         print("RSLT follows")
+#         pprint(rslt)
+#         print("RSLT above")
+#         assert_json_matches_schema(rslt, "entity_metadata_schema.yml")
+#         return rslt
+
+#     def get_entity_type(self) -> str:
+#         try:
+#             entity_type = self.entity_data["entity_type"]
+#             assert entity_type is not None
+#             return entity_type
+#         except Exception as excp:
+#             raise EntityUpdateException(
+#                 f"""
+#                 Could not find entity type for {self.uuid}.
+#                 Error {excp}
+#                 """
+#             )
+
+#     @cached_property
+#     def fields_to_chnge(self) -> dict:
+#         return ()
+
+#     def update(self) -> None:
+#         """
+#         This is the main method for using the EntityUpdater.
+#         - Appends values of fields_to_append_to to existing entity-api fields.
+#         - Compiles fields to change: fields_to_overwrite + appended fields,
+#         ensuring there are no duplicates.
+#         - Validates existence of fields_to_change against fields in entity-api data.
+#         - If send_to_status_changer and "status" is found in fields_to_change,
+#         creates a StatusChanger instance and passes validated data.
+#         - Otherwise, makes a PUT request with fields_to_change payload to entity-api.
+#         - Returns response.json() or raises Exception.
+#         """
+#         pass
+
+#     def _validate_fields_to_change(self):
+#         #raise RuntimeError("I want to do away with this method")
+#         pass
+
+    
+# class StatusChanger(EntityUpdater):
+#     def __init__(
+#         self,
+#         uuid: str,
+#         token: str,
+#         http_conn_id: str = "entity_api_connection",
+#         fields_to_overwrite: Optional[dict] = None,
+#         fields_to_append_to: Optional[dict] = None,
+#         delimiter: str = "|",
+#         extra_options: Optional[dict] = None,
+#         verbose: bool = True,
+#         # Additional fields added to support privileged field "status"
+#         status: Optional[Union[Statuses, str]] = None,
+#         entity_type: Optional[Literal["Dataset", "Upload", "Publication"]] = None,
+#     ):
+#         super().__init__(
+#             uuid,
+#             token,
+#             http_conn_id,
+#             fields_to_overwrite,
+#             fields_to_append_to,
+#             delimiter,
+#             extra_options,
+#             verbose
+#         )
+
+#     def send_email(self):
+#         raise RuntimeError("I wanted to move this elsewere")
+######## New Version Above
+    
 class EntityUpdater:
     def __init__(
         self,
@@ -265,6 +383,7 @@ class StatusChanger:
             getattr(self, func)(**args)
 
     def _validate_fields_to_change(self):
+        logging.info(f"StatusChanger 4a: {self.fields_to_change} {self.status}")
         self.fields_to_change["status"] = self.status
 
     def _get_status(self, status: str) -> Optional[Statuses]:

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -276,7 +276,6 @@ class StatusChanger:
             getattr(self, func)(**args)
 
     def _validate_fields_to_change(self):
-        logging.info(f"StatusChanger 4a: {self.fields_to_change} {self.status}")
         self.fields_to_change["status"] = self.status
 
     def _get_status(self, status: str) -> Optional[Statuses]:

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -23,116 +23,6 @@ from schema_utils import (
 ENTITY_JSON_SCHEMA = "entity_metadata_schema.yml"  # from this repo's schemata directory
 
 
-# class StatusChangeAction:
-#     def __init__(self, callback):
-#         self.callback = callback
-
-#     def run(self, **kwargs):
-#         self.callback(**kwargs)
-
-
-# STATUS_CHANGE_TRIGGER_TBL = {
-#     ("*", "error"): [StatusChangeAction(send_email)]
-# }
-
-
-# class EntityUpdater:
-#     def __init__(
-#         self,
-#         uuid: str,
-#         token: str,
-#         http_conn_id: str = "entity_api_connection",
-#         fields_to_overwrite: Optional[dict] = None,
-#         fields_to_append_to: Optional[dict] = None,
-#         delimiter: str = "|",
-#         extra_options: Optional[dict] = None,
-#         verbose: bool = True,
-#     ):
-#         self.uuid = uuid
-#         self.token = token
-#         self.http_conn_id = http_conn_id
-#         self.fields_to_overwrite = fields_to_overwrite if fields_to_overwrite else {}
-#         self.fields_to_append_to = fields_to_append_to if fields_to_append_to else {}
-#         self.delimiter = delimiter
-#         self.extra_options = extra_options if extra_options else {}
-#         self.verbose = verbose
-#         self.entity_type = self.get_entity_type()
-
-#     @cached_property
-#     def entity_data(self):
-#         rslt = get_submission_context(self.token, self.uuid)
-#         from pprint import pprint
-#         print("RSLT follows")
-#         pprint(rslt)
-#         print("RSLT above")
-#         assert_json_matches_schema(rslt, "entity_metadata_schema.yml")
-#         return rslt
-
-#     def get_entity_type(self) -> str:
-#         try:
-#             entity_type = self.entity_data["entity_type"]
-#             assert entity_type is not None
-#             return entity_type
-#         except Exception as excp:
-#             raise EntityUpdateException(
-#                 f"""
-#                 Could not find entity type for {self.uuid}.
-#                 Error {excp}
-#                 """
-#             )
-
-#     @cached_property
-#     def fields_to_chnge(self) -> dict:
-#         return ()
-
-#     def update(self) -> None:
-#         """
-#         This is the main method for using the EntityUpdater.
-#         - Appends values of fields_to_append_to to existing entity-api fields.
-#         - Compiles fields to change: fields_to_overwrite + appended fields,
-#         ensuring there are no duplicates.
-#         - Validates existence of fields_to_change against fields in entity-api data.
-#         - If send_to_status_changer and "status" is found in fields_to_change,
-#         creates a StatusChanger instance and passes validated data.
-#         - Otherwise, makes a PUT request with fields_to_change payload to entity-api.
-#         - Returns response.json() or raises Exception.
-#         """
-#         pass
-
-#     def _validate_fields_to_change(self):
-#         #raise RuntimeError("I want to do away with this method")
-#         pass
-
-    
-# class StatusChanger(EntityUpdater):
-#     def __init__(
-#         self,
-#         uuid: str,
-#         token: str,
-#         http_conn_id: str = "entity_api_connection",
-#         fields_to_overwrite: Optional[dict] = None,
-#         fields_to_append_to: Optional[dict] = None,
-#         delimiter: str = "|",
-#         extra_options: Optional[dict] = None,
-#         verbose: bool = True,
-#         # Additional fields added to support privileged field "status"
-#         status: Optional[Union[Statuses, str]] = None,
-#         entity_type: Optional[Literal["Dataset", "Upload", "Publication"]] = None,
-#     ):
-#         super().__init__(
-#             uuid,
-#             token,
-#             http_conn_id,
-#             fields_to_overwrite,
-#             fields_to_append_to,
-#             delimiter,
-#             extra_options,
-#             verbose
-#         )
-
-#     def send_email(self):
-#         raise RuntimeError("I wanted to move this elsewere")
-######## New Version Above
     
 class EntityUpdater:
     def __init__(
@@ -158,7 +48,9 @@ class EntityUpdater:
 
     @cached_property
     def entity_data(self):
-        return get_submission_context(self.token, self.uuid)
+        rslt = get_submission_context(self.token, self.uuid)
+        assert_json_matches_schema(rslt, "entity_metadata_schema.yml")
+        return rslt
 
     def get_entity_type(self):
         try:
@@ -214,6 +106,7 @@ class EntityUpdater:
             {self.fields_to_change}
             """
         )
+        assert_json_matches_schema(self.fields_to_change, "entity_metadata_schema.yml")
         if self.verbose:
             logging.info(f"Updating {self.uuid} with data {self.fields_to_change}...")
         try:

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -89,7 +89,6 @@ class EntityUpdater:
     @cached_property
     def entity_data(self):
         rslt = get_submission_context(self.token, self.uuid)
-        assert_json_matches_schema(rslt, "entity_metadata_schema.yml")
         return rslt
 
     def get_entity_type(self):
@@ -146,7 +145,9 @@ class EntityUpdater:
             {self.fields_to_change}
             """
         )
-        assert_json_matches_schema(self.fields_to_change, "entity_metadata_schema.yml")
+        updated_entity_data = self.entity_data.copy()
+        updated_entity_data.update(self.fields_to_change)
+        assert_json_matches_schema(updated_entity_data, "entity_metadata_schema.yml")
         if self.verbose:
             logging.info(f"Updating {self.uuid} with data {self.fields_to_change}...")
         try:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -781,7 +781,7 @@ def get_file_metadata_dict(
         matcher = PipelineFileMatcher.create_from_files(pipeline_file_manifests)
     file_info = get_file_metadata(root_dir, matcher)
     if len(file_info) > max_in_line_files:
-        localized_assert_json_matches_schema(file_info, "file_info_schema.yml")
+        assert_json_matches_schema(file_info, "file_info_schema.yml")
         fpath = join(alt_file_dir, "{}.json".format(uuid.uuid4()))
         with open(fpath, "w") as f:
             json.dump({"files": file_info}, f)
@@ -1610,7 +1610,7 @@ def make_send_status_msg_function(
                         contacts = ds_rslt.get("contacts", [])
 
             try:
-                localized_assert_json_matches_schema(
+                assert_json_matches_schema(
                     md,
                     "dataset_metadata_schema.yml"
                 )
@@ -1724,7 +1724,7 @@ def _get_workflow_map() -> List[Tuple[Pattern, Pattern, str]]:
         map_path = join(dirname(__file__), WORKFLOW_MAP_FILENAME)
         with open(map_path, "r") as f:
             map = yaml.safe_load(f)
-        localized_assert_json_matches_schema(map, WORKFLOW_MAP_SCHEMA)
+        assert_json_matches_schema(map, WORKFLOW_MAP_SCHEMA)
         cmp_map = []
         for dct in map["workflow_map"]:
             ct_re = re.compile(dct["collection_type"])
@@ -1743,7 +1743,7 @@ def _get_resource_map() -> List[Tuple[Pattern, Pattern, Dict[str, str]]]:
         map_path = join(dirname(__file__), RESOURCE_MAP_FILENAME)
         with open(map_path, "r") as f:
             map = yaml.safe_load(f)
-        localized_assert_json_matches_schema(map, RESOURCE_MAP_SCHEMA)
+        assert_json_matches_schema(map, RESOURCE_MAP_SCHEMA)
         cmp_map = []
         for dct in map["resource_map"]:
             dag_re = re.compile(dct["dag_re"])
@@ -1958,7 +1958,7 @@ def main():
         "dag_provenance_list": get_git_provenance_list(__file__),
     }
     try:
-        localized_assert_json_matches_schema(md, "dataset_metadata_schema.yml")
+        assert_json_matches_schema(md, "dataset_metadata_schema.yml")
         print("ASSERT passed")
     except AssertionError as e:
         print(f"ASSERT failed {e}")

--- a/src/ingest-pipeline/airflow/dags/validate_upload.py
+++ b/src/ingest-pipeline/airflow/dags/validate_upload.py
@@ -45,7 +45,7 @@ default_args = {
     "email": ["gesina@psc.edu"],
     "email_on_failure": False,
     "email_on_retry": False,
-    "on_failure_callback": FailureCallback,
+    "on_failure_callback": FailureCallback(__name__),
     "retries": 1,
     "retry_delay": timedelta(minutes=1),
     "xcom_push": True,

--- a/src/ingest-pipeline/schemata/entity_metadata_schema.yml
+++ b/src/ingest-pipeline/schemata/entity_metadata_schema.yml
@@ -10,14 +10,15 @@
   'entity_metadata':
      'type': 'object'
      'properties':
-        'dag_provenance': {'$ref': 'code_provenance_info_schema.yml#/definitions/code_provenance_info'}
-        'dag_provenance_list': {'$ref': 'code_provenance_info_list_schema.yml#/definitions/code_provenance_info_list'}
-        'files': {'$ref': 'file_info_schema.yml#/definitions/file_info'}
-        'files_info_alt_path': {'type': 'string'}
-        'entity_type': {
+#        'dag_provenance': {'$ref': 'code_provenance_info_schema.yml#/definitions/code_provenance_info'}
+#        'dag_provenance_list': {'$ref': 'code_provenance_info_list_schema.yml#/definitions/code_provenance_info_list'}
+#        'files': {'$ref': 'file_info_schema.yml#/definitions/file_info'}
+#        'files_info_alt_path':
+#          'type': 'string'
+        'entity_type':
           'type': 'string'
           'enum': ['Upload', 'Dataset', 'Publication']
-          }
-     'oneOf':
-       - 'required': ['dag_provenance']
-       - 'required': ['dag_provenance_list']
+#     'required': ['entity_type']
+#    'oneOf':
+#       - 'required': ['dag_provenance']
+#       - 'required': ['dag_provenance_list']

--- a/src/ingest-pipeline/schemata/entity_metadata_schema.yml
+++ b/src/ingest-pipeline/schemata/entity_metadata_schema.yml
@@ -10,15 +10,62 @@
   'entity_metadata':
      'type': 'object'
      'properties':
-#        'dag_provenance': {'$ref': 'code_provenance_info_schema.yml#/definitions/code_provenance_info'}
-#        'dag_provenance_list': {'$ref': 'code_provenance_info_list_schema.yml#/definitions/code_provenance_info_list'}
-#        'files': {'$ref': 'file_info_schema.yml#/definitions/file_info'}
-#        'files_info_alt_path':
-#          'type': 'string'
         'entity_type':
           'type': 'string'
           'enum': ['Upload', 'Dataset', 'Publication']
-#     'required': ['entity_type']
-#    'oneOf':
-#       - 'required': ['dag_provenance']
-#       - 'required': ['dag_provenance_list']
+        'status':
+          'type': 'string'
+          'enum':
+            - 'deprecated'
+            - 'error'
+            - 'hold'
+            - 'valid'
+            - 'invalid'
+            - 'new'
+            - 'processing'
+            - 'published'
+            - 'qa'
+            - 'submitted'
+            - 'error'
+            - 'hold'
+            - 'reorganized'
+     'anyOf':
+      - 'properties':
+           'entity_type': { 'const': 'Upload' }
+           'status':
+             'anyOf':
+               - {'const': 'error'}
+               - {'const': 'invalid'}
+               - {'const': 'new'}
+               - {'const': 'processing'}
+               - {'const': 'reorganized'}
+               - {'const': 'submitted'}
+               - {'const': 'valid'}
+        'required': ['entity_type', 'status']
+      - 'properties':
+           'entity_type': { 'const': 'Dataset' }
+           'status':
+             'anyOf':
+               - {'const': 'deprecated'}
+               - {'const': 'error'}
+               - {'const': 'hold'}
+               - {'const': 'invalid'}
+               - {'const': 'new'}
+               - {'const': 'processing'}
+               - {'const': 'published'}
+               - {'const': 'qa'}
+               - {'const': 'submitted'}
+        'required': ['entity_type', 'status']
+      - 'properties':
+           'entity_type': { 'const': 'Publication' }
+           'status':
+             'anyOf':
+               - {'const': 'error'}
+               - {'const': 'hold'}
+               - {'const': 'invalid'}
+               - {'const': 'new'}
+               - {'const': 'processing'}
+               - {'const': 'published'}
+               - {'const': 'qa'}
+               - {'const': 'submitted'}
+        'required': ['entity_type', 'status']

--- a/src/ingest-pipeline/schemata/entity_metadata_schema.yml
+++ b/src/ingest-pipeline/schemata/entity_metadata_schema.yml
@@ -33,39 +33,18 @@
       - 'properties':
            'entity_type': { 'const': 'Upload' }
            'status':
-             'anyOf':
-               - {'const': 'error'}
-               - {'const': 'invalid'}
-               - {'const': 'new'}
-               - {'const': 'processing'}
-               - {'const': 'reorganized'}
-               - {'const': 'submitted'}
-               - {'const': 'valid'}
+             'enum': ['error', 'invalid', 'new', 'processing', 'reorganized',
+                      'submitted', 'valid']
         'required': ['entity_type', 'status']
       - 'properties':
            'entity_type': { 'const': 'Dataset' }
            'status':
-             'anyOf':
-               - {'const': 'deprecated'}
-               - {'const': 'error'}
-               - {'const': 'hold'}
-               - {'const': 'invalid'}
-               - {'const': 'new'}
-               - {'const': 'processing'}
-               - {'const': 'published'}
-               - {'const': 'qa'}
-               - {'const': 'submitted'}
+             'enum': ['deprecated', 'error', 'hold', 'invalid', 'new',
+                      'processing', 'published', 'qa', 'submitted']
         'required': ['entity_type', 'status']
       - 'properties':
            'entity_type': { 'const': 'Publication' }
            'status':
-             'anyOf':
-               - {'const': 'error'}
-               - {'const': 'hold'}
-               - {'const': 'invalid'}
-               - {'const': 'new'}
-               - {'const': 'processing'}
-               - {'const': 'published'}
-               - {'const': 'qa'}
-               - {'const': 'submitted'}
+             'enum': ['error', 'hold', 'invalid', 'new',
+                      'processing', 'published', 'qa', 'submitted']
         'required': ['entity_type', 'status']

--- a/src/ingest-pipeline/schemata/entity_metadata_schema.yml
+++ b/src/ingest-pipeline/schemata/entity_metadata_schema.yml
@@ -1,0 +1,23 @@
+'$schema': 'http://json-schema.org/schema#'
+'$id': 'http://schemata.hubmapconsortium.org/entity_metadata_schema.yml'
+'title': 'entity metadata schema'
+'description': 'entity metadata schema'
+
+'allOf': [{'$ref': '#/definitions/entity_metadata'}]
+
+'definitions':
+
+  'entity_metadata':
+     'type': 'object'
+     'properties':
+        'dag_provenance': {'$ref': 'code_provenance_info_schema.yml#/definitions/code_provenance_info'}
+        'dag_provenance_list': {'$ref': 'code_provenance_info_list_schema.yml#/definitions/code_provenance_info_list'}
+        'files': {'$ref': 'file_info_schema.yml#/definitions/file_info'}
+        'files_info_alt_path': {'type': 'string'}
+        'entity_type': {
+          'type': 'string'
+          'enum': ['Upload', 'Dataset', 'Publication']
+          }
+     'oneOf':
+       - 'required': ['dag_provenance']
+       - 'required': ['dag_provenance_list']

--- a/tests/test_status_changer.py
+++ b/tests/test_status_changer.py
@@ -84,7 +84,8 @@ class TestEntityUpdater(unittest.TestCase):
             )
 
     def test_unrecognized_status(self):
-        with patch("status_change.status_manager.get_submission_context"):
+        with patch("status_change.status_manager.get_submission_context") as gsc_mock:
+            gsc_mock.return_value = self.good_context
             with self.assertRaises(EntityUpdateException):
                 StatusChanger(
                     "invalid_status_uuid",

--- a/tests/test_status_changer.py
+++ b/tests/test_status_changer.py
@@ -1,5 +1,6 @@
 # Run from dags dir as `python -m unittest status_change.tests.test_status_changer`
 import unittest
+import logging
 from functools import cached_property
 from unittest.mock import MagicMock, patch
 
@@ -80,7 +81,6 @@ class TestEntityUpdater(unittest.TestCase):
     @cached_property
     def upload_valid(self):
         with patch("status_change.status_manager.get_submission_context") as mock_mthd:
-#            mock_mthd.return_value={"entity_type":"Upload"}
             return StatusChanger(
                 "upload_valid_uuid",
                 "upload_valid_token",
@@ -156,23 +156,6 @@ class TestEntityUpdater(unittest.TestCase):
         with_extra_option_and_field.update()
         self.assertIn({"check_response": False}, hhr_mock.call_args.args)
         self.assertIn('{"test_extra_field": true, "status": "valid"}', hhr_mock.call_args.args)
-
-    @patch("status_change.status_manager.get_submission_context")
-    @patch("status_change.status_manager.HttpHook.run")
-    def test_extra_fields_bad(self, hhr_mock, context_mock):
-        context_mock.return_value = {
-            "status": "processing",
-            "entity_type": "Upload",
-        }
-        with_extra_option_and_field = StatusChanger(
-            "extra_options_uuid",
-            "extra_options_token",
-            status=Statuses.UPLOAD_VALID,
-            fields_to_overwrite={"test_extra_field": True},
-            verbose=False,
-        )
-        self.assertRaises(Exception, with_extra_option_and_field.update)
-        hhr_mock.assert_not_called()
 
     @patch("status_change.status_manager.HttpHook.run")
     def test_valid_status_in_request(self, hhr_mock):

--- a/tests/test_status_changer.py
+++ b/tests/test_status_changer.py
@@ -10,6 +10,7 @@ from status_change.status_manager import (
     StatusChanger,
     Statuses,
 )
+from status_change.slack_formatter import format_priority_reorganized_msg
 from utils import pythonop_set_dataset_state
 
 
@@ -264,7 +265,8 @@ class TestEntityUpdater(unittest.TestCase):
     @patch("status_change.slack_formatter.get_organ")
     @patch("status_change.slack_formatter.get_submission_context")
     def test_upload_reorganized_priority_slack(self, context_mock, organ_mock, slack_mock):
-        with patch("status_change.status_manager.get_submission_context"):
+        with patch("status_change.status_manager.get_submission_context") as mock_gsc:
+            mock_gsc.return_value = self.context_mock_value
             with patch("status_change.status_manager.StatusChanger._set_entity_api_data"):
                 context_mock.return_value = self.context_mock_value
                 organ_mock.return_value = "TO"


### PR DESCRIPTION
This PR:
* Adds a jsonschema test to updates that are committed to entity-api
* Restructures EntityUpdater and StatusChanger so that StatusChanger is now a derived class of EntityUpdater.  This saves
  a lot of code.  The one downside is that if you try to change status using an EntityUpdater, it raises an exception rather than
  creating a StatusChanger.
* Causes EntityUpdater to refuse attempts to change entity_type.
* Changes FailureUpload from a class to an instance with a __call__() method
* Adds a few unit tests.
* Introduces StatusChangeAction as a way of encapsulating the special actions like sending a Slack message that a status
  change may cause.
* Makes minor mods to existing unit tests to get them past the JsonSchema validation.
* Uses pformat in place of pprint in one instance.