### PR TITLE
fix unittest_runner return code

### DIFF
--- a/tests/unittest_runner.py
+++ b/tests/unittest_runner.py
@@ -55,7 +55,8 @@ def main():
             tests = loader.loadTestsFromNames(test_names)
         else:
             tests = loader.discover(Path(__file__).parent)
-        sys.exit(runner.run(tests))
+        rslt = runner.run(tests)
+        sys.exit(len(rslt.errors) + len(rslt.failures))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Trivial change- unittest_runner.py was reporting no errors but returning a non-zero return code.  This broke the newly added CI action.