### PR TITLE
Welling/rebuild files

### DIFF
--- a/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
+++ b/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
@@ -1,11 +1,16 @@
-from airflow.operators.empty import EmptyOperator
+from pprint import pprint
 from datetime import datetime, timedelta
+
+from airflow.operators.python import PythonOperator
+from airflow.exceptions import AirflowException
+from airflow.configuration import conf as airflow_conf
 
 from utils import (
     HMDAG,
     get_queue_resource,
     get_preserve_scratch_resource,
     create_dataset_state_error_callback,
+    make_send_status_msg_function,
     get_tmp_dir_path,
 )
 
@@ -54,4 +59,106 @@ with HMDAG('rebuild_processed_dataset_metadata',
         task_id='empty_operator'
     )
 
-    t_empty_operator
+    t_create_tmpdir = CreateTmpDirOperator(task_id="create_temp_dir")
+
+    t_cleanup_tmpdir = CleanupTmpDirOperator(task_id="cleanup_temp_dir")
+
+    def check_one_uuid(uuid, **kwargs):
+        """
+        Look up information on the given uuid or HuBMAP identifier.
+        Returns:
+        - the uuid, translated from an identifier if necessary
+        - data type(s) of the dataset
+        - local directory full path of the dataset
+        """
+        print(f"Starting uuid {uuid}")
+        my_callable = lambda **kwargs: uuid
+        ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=my_callable, **kwargs)
+        if not ds_rslt:
+            raise AirflowException(f"Invalid uuid/doi for group: {uuid}")
+        print("ds_rslt:")
+        pprint(ds_rslt)
+
+        for key in ["status", "uuid", "local_directory_full_path", "metadata"]:
+            assert key in ds_rslt, f"Dataset status for {uuid} has no {key}"
+
+        if not ds_rslt["status"] in ["New", "Error", "QA", "Published", "Submitted"]:
+            raise AirflowException(f"Dataset {uuid} is not QA or better")
+
+        return (ds_rslt["uuid"], ds_rslt["local_directory_full_path"], ds_rslt["metadata"])
+
+    def check_uuids(**kwargs):
+        print("dag_run conf follows:")
+        pprint(kwargs["dag_run"].conf)
+
+        try:
+            assert_json_matches_schema(
+                kwargs["dag_run"].conf, "launch_checksums_metadata_schema.yml"
+            )
+        except AssertionError as e:
+            print("invalid metadata follows:")
+            pprint(kwargs["dag_run"].conf)
+            raise
+
+        uuid, lz_path, metadata = check_one_uuid(kwargs["dag_run"].conf["uuid"], **kwargs)
+        print(f"filtered metadata: {metadata}")
+        print(f"filtered paths: {lz_path}")
+        kwargs["dag_run"].conf["lz_path"] = lz_path
+        kwargs["dag_run"].conf["src_path"] = airflow_conf.as_dict()["connections"][
+            "src_path"
+        ].strip("'")
+
+    t_check_uuids = PythonOperator(
+        task_id="check_uuids",
+        python_callable=check_uuids,
+        provide_context=True,
+        op_kwargs={
+            "crypt_auth_tok": encrypt_tok(
+                airflow_conf.as_dict()["connections"]["APP_CLIENT_SECRET"]
+            ).decode(),
+        },
+    )
+
+    def additional_md_function(**kwargs):
+        """
+        This is a hook for future development.  Metadata returned here will
+        be updated on the dataset.
+        """
+        return {}
+
+    send_status_msg = make_send_status_msg_function(
+        dag_file=__file__,
+        retcode_ops=["check_uuids"],
+        cwl_workflows=[],
+        dataset_uuid_fun=get_dataset_uuid,
+        dataset_lz_path_fun=get_dataset_lz_path,
+        metadata_fun=additional_md_function,
+        include_file_metadata=True,
+    )
+
+    def wrapped_send_status_msg(**kwargs):
+        if send_status_msg(**kwargs):
+            # These xcom values are used to chain to potential downstream workflows-
+            # very unlikely in this application but we might as well make sure they exist.
+            kwargs["ti"].xcom_push(key="collectiontype", value=None)
+            kwargs["ti"].xcom_push(key="assay_type", value=None)
+
+    t_send_status = PythonOperator(
+        task_id="send_status_msg",
+        python_callable=wrapped_send_status_msg,
+        provide_context=True,
+        trigger_rule="all_done",
+        op_kwargs={
+            "crypt_auth_tok": encrypt_tok(
+                airflow_conf.as_dict()["connections"]["APP_CLIENT_SECRET"]
+            ).decode(),
+        },
+    )
+
+    (
+        t_check_uuids
+        >> t_create_tmpdir
+        >> t_send_status  # new metadata is scanned in during this step
+        >> t_cleanup_tmpdir
+    )
+

--- a/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
+++ b/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
@@ -86,9 +86,6 @@ with HMDAG('rebuild_processed_dataset_metadata',
         for key in ["status", "uuid", "local_directory_full_path", "metadata"]:
             assert key in ds_rslt, f"Dataset status for {uuid} has no {key}"
 
-        if not ds_rslt["status"] in ["New", "Error", "QA", "Published", "Submitted"]:
-            raise AirflowException(f"Dataset {uuid} is not QA or better")
-
         return (ds_rslt["uuid"], ds_rslt["local_directory_full_path"], ds_rslt["metadata"])
 
     def check_uuids(**kwargs):

--- a/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
+++ b/src/ingest-pipeline/airflow/dags/rebuild_processed_dataset_metadata.py
@@ -150,7 +150,7 @@ with HMDAG('rebuild_processed_dataset_metadata',
             else:
                 raise AirflowException("send_status_msg returned False")
         except Exception as excp:
-            raise AirflowException(f"Exception clause 2: {excp}") from excp
+            raise AirflowException(f"setting dataset attributes failed: {excp}") from excp
 
     t_send_status = PythonOperator(
         task_id="send_status_msg",

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -146,7 +146,10 @@ class EntityUpdater:
         )
         original_entity_type = self.entity_data.get("entity_type")
         updated_entity_data = self.entity_data.copy()
-        updated_entity_data.update(self.fields_to_change)
+        update_fields = self.fields_to_change.copy()
+        if "status" in update_fields and update_fields["status"] is None:
+            update_fields.pop("status")  # avoid setting status to None for test
+        updated_entity_data.update(update_fields)
         updated_entity_type = updated_entity_data.get("entity_type")
         if original_entity_type != updated_entity_type:
             raise EntityUpdateException(

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -161,10 +161,10 @@ class EntityUpdater:
         except AssertionError as excp:
             raise EntityUpdateException(excp) from excp
         if self.verbose:
-            logging.info(f"Updating {self.uuid} with data {self.fields_to_change}...")
+            logging.info(f"Updating {self.uuid} with data {update_fields}...")
         try:
             response = http_hook.run(
-                endpoint, json.dumps(self.fields_to_change), headers, self.extra_options
+                endpoint, json.dumps(update_fields), headers, self.extra_options
             )
         except Exception as e:
             raise EntityUpdateException(

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -130,13 +130,17 @@ class EntityUpdater:
 
     @staticmethod
     def _enums_to_lowercase(data: Any) -> Any:
-        # Lowercase all strings which appear as dictionary values
+        """
+        Lowercase all strings which appear as dictionary values.
+        This modifies the passed data in place, rather than making
+        a copy!
+        """
         if isinstance(data, dict):
             for key, val in data.items():
                 if isinstance(val, str):
                     data[key] = val.lower()
                 else:
-                    data[key] = EntityUpdater._enums_to_lowercase(key)
+                    data[key] = EntityUpdater._enums_to_lowercase(val)
             return data
         elif isinstance(data, list):
             return [EntityUpdater._enums_to_lowercase(val) for val in data]

--- a/src/ingest-pipeline/schemata/entity_metadata_schema.yml
+++ b/src/ingest-pipeline/schemata/entity_metadata_schema.yml
@@ -12,7 +12,7 @@
      'properties':
         'entity_type':
           'type': 'string'
-          'enum': ['Upload', 'Dataset', 'Publication']
+          'enum': ['upload', 'dataset', 'publication']
         'status':
           'type': 'string'
           'enum':
@@ -31,19 +31,19 @@
             - 'reorganized'
      'anyOf':
       - 'properties':
-           'entity_type': { 'const': 'Upload' }
+           'entity_type': { 'const': 'upload' }
            'status':
              'enum': ['error', 'invalid', 'new', 'processing', 'reorganized',
                       'submitted', 'valid']
         'required': ['entity_type', 'status']
       - 'properties':
-           'entity_type': { 'const': 'Dataset' }
+           'entity_type': { 'const': 'dataset' }
            'status':
              'enum': ['deprecated', 'error', 'hold', 'invalid', 'new',
                       'processing', 'published', 'qa', 'submitted']
         'required': ['entity_type', 'status']
       - 'properties':
-           'entity_type': { 'const': 'Publication' }
+           'entity_type': { 'const': 'publication' }
            'status':
              'enum': ['error', 'hold', 'invalid', 'new',
                       'processing', 'published', 'qa', 'submitted']


### PR DESCRIPTION
This adds enough content to dags/rebuild_processed_dataset_metadata.py to properly rebuild and replace the "files" data for a derived dataset.  Some minor changes to related components are also necessary.

To deal with the fact that EntityUpdater thinks in lowercase (e.g. "qa") while the actual entity data sometimes uses uppercase, the entity data schema has been modified to use lowercase enums and the data is passed through a lowercasing filter before validation.