### PR TITLE
use --threadpool_limit instead of --processes for sprm

### DIFF
--- a/src/ingest-pipeline/airflow/dags/phenocycler_deepcell.py
+++ b/src/ingest-pipeline/airflow/dags/phenocycler_deepcell.py
@@ -175,7 +175,7 @@ with HMDAG(
 
         input_parameters = [
             {"parameter_name": "--enable_manhole", "value": ""},
-            {"parameter_name": "--processes", "value": get_threads_resource(dag.dag_id)},
+            {"parameter_name": "--threadpool_limit", "value": get_threads_resource(dag.dag_id)},
             {"parameter_name": "--image_dir", "value": str(data_dir / "pipeline_output/expr")},
             {"parameter_name": "--mask_dir", "value": str(data_dir / "pipeline_output/mask")},
         ]


### PR DESCRIPTION
This mod applies the value of the resource "threads" in the phenocycler_deepcell CWL call to --threadpool_limit rather than --processes.  This leaves --processes to default back to 1.  

The value of --processes gets applied to processing multiple ome.tiff files in parallel, but since there is only one such file for phenocycler this doesn't help.  --threadpool_limit is mapped to the corresponding call of the threadpoolctl module by a recent mod to the SPRM container, and this should help to control the number of threads used by the matrix math routines.  Without this mod that value is defaulting to the number of cores, which is way too large and competes with other jobs.