### PR TITLE
Slack bugfix

### DIFF
--- a/src/ingest-pipeline/airflow/dags/status_change/slack/base.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack/base.py
@@ -5,20 +5,23 @@ from status_change.status_utils import (
     get_abs_path,
     get_hubmap_id_from_uuid,
     get_submission_context,
+    slack_channels,
 )
-
-from airflow.configuration import conf as airflow_conf
 
 
 class SlackMessage:
-    # Name should match what's in airflow_conf.slack_channels
+    # Name should match what's in status_utils.slack_channels
     name = "base"
 
     def __init__(self, uuid: str, token: str, entity_data: Optional[dict] = None):
         self.uuid = uuid
         self.token = token
-        self.channel = airflow_conf.as_dict().get("slack_channels", {}).get(self.name.upper())
+        self.channel = slack_channels.get(self.name, "")
         self.entity_data = entity_data if entity_data else get_submission_context(token, uuid)
+
+    @classmethod
+    def get_channel(cls):
+        return slack_channels.get(cls.name, "")
 
     @classmethod
     def test(cls, entity_data: dict, token: str) -> bool:

--- a/src/ingest-pipeline/airflow/dags/status_change/slack_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack_manager.py
@@ -95,8 +95,8 @@ class SlackManager:
         try:
             env = get_env()
         except Exception as e:
-            logging.info(f"Error retrieving env, defaulting to DEV. {e}")
             env = "dev"
+            logging.info(f"Error retrieving env, defaulting to DEV. {e}")
         if env == "prod":
             channel = self.message_class.channel
         else:
@@ -105,7 +105,10 @@ class SlackManager:
                 f"Non-prod environment, switching channel from {self.message_class.channel} to {channel}."
             )
         if not channel:
-            channel = SlackMessage.get_channel()  # always default to base channel
+            channel = SlackMessage.get_channel()
+            logging.info(
+                f"No channel found for message class {self.message_class.name} on {env}, using default channel."
+            )
         logging.info(f"Sending message from {self.message_class.name}...")
         logging.info(f"Channel: {channel}")
         logging.info(f"Message: {message}")

--- a/src/ingest-pipeline/airflow/dags/status_change/slack_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack_manager.py
@@ -92,7 +92,12 @@ class SlackManager:
         if not self.message_class:
             return
         message = self.message_class.format()
-        if get_env() == "prod":
+        try:
+            env = get_env()
+        except Exception as e:
+            logging.info(f"Error retrieving env, defaulting to DEV. {e}")
+            env = "dev"
+        if env == "prod":
             channel = self.message_class.channel
         else:
             channel = slack_channels_testing.get(self.message_class.name)

--- a/src/ingest-pipeline/airflow/dags/status_change/slack_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack_manager.py
@@ -15,8 +15,10 @@ from .slack.reorganized import SlackUploadReorganized, SlackUploadReorganizedPri
 from .status_utils import (
     EntityUpdateException,
     Statuses,
+    get_env,
     get_submission_context,
     post_to_slack_notify,
+    slack_channels_testing,
 )
 
 
@@ -40,41 +42,40 @@ class SlackManager:
             )
         self.is_valid_for_status = bool(self.message_class)
 
-    @property
-    def status_to_class(self):
         """
         This is the source of truth for what classes should be used for a given status.
         Format:
             Statuses.STATUS: {"main_class": <class_name>, "subclasses": [<class_name>]}
         """
-        return {
-            Statuses.DATASET_ERROR: {
-                "main_class": SlackDatasetError,
-                "subclasses": [],
-                # "subclasses": [SlackDatasetErrorPrimary, SlackDatasetErrorDerived],
-            },
-            Statuses.DATASET_INVALID: {
-                "main_class": SlackDatasetInvalid,
-                "subclasses": [],
-                # "subclasses": [SlackDatasetInvalidDerived],
-            },
-            Statuses.DATASET_QA: {
-                "main_class": SlackDatasetQA,
-                "subclasses": [],
-            },
-            Statuses.UPLOAD_ERROR: {
-                "main_class": SlackUploadError,
-                "subclasses": [],
-            },
-            Statuses.UPLOAD_INVALID: {
-                "main_class": SlackUploadInvalid,
-                "subclasses": [],
-            },
-            Statuses.UPLOAD_REORGANIZED: {
-                "main_class": SlackUploadReorganized,
-                "subclasses": [SlackUploadReorganizedPriority],
-            },
-        }
+
+    status_to_class = {
+        Statuses.DATASET_ERROR: {
+            "main_class": SlackDatasetError,
+            "subclasses": [],
+            # "subclasses": [SlackDatasetErrorPrimary, SlackDatasetErrorDerived],
+        },
+        Statuses.DATASET_INVALID: {
+            "main_class": SlackDatasetInvalid,
+            "subclasses": [],
+            # "subclasses": [SlackDatasetInvalidDerived],
+        },
+        Statuses.DATASET_QA: {
+            "main_class": SlackDatasetQA,
+            "subclasses": [],
+        },
+        Statuses.UPLOAD_ERROR: {
+            "main_class": SlackUploadError,
+            "subclasses": [],
+        },
+        Statuses.UPLOAD_INVALID: {
+            "main_class": SlackUploadInvalid,
+            "subclasses": [],
+        },
+        Statuses.UPLOAD_REORGANIZED: {
+            "main_class": SlackUploadReorganized,
+            "subclasses": [SlackUploadReorganizedPriority],
+        },
+    }
 
     def get_message_class(self, msg_type: Statuses) -> Optional[SlackMessage]:
         relevant_classes = self.status_to_class.get(msg_type)
@@ -91,14 +92,21 @@ class SlackManager:
         if not self.message_class:
             return
         message = self.message_class.format()
-        channel = str(self.message_class.channel)
-        logging.info(f"Sending message from {self.message_class.name}...")
-        if message and channel:
-            post_to_slack_notify(self.token, message, channel)
-        elif not message:
-            raise EntityUpdateException(f"Request to send Slack message missing message text.")
-        elif not channel:
-            # This is likely a config issue, let's soft fail here
+        if get_env() == "prod":
+            channel = self.message_class.channel
+        else:
+            channel = slack_channels_testing.get(self.message_class.name)
             logging.info(
-                f"Request to send Slack message missing target channel. No Slack message will be sent."
+                f"Non-prod environment, switching channel from {self.message_class.channel} to {channel}."
             )
+        if not channel:
+            channel = SlackMessage.get_channel()  # always default to base channel
+        logging.info(f"Sending message from {self.message_class.name}...")
+        logging.info(f"Channel: {channel}")
+        logging.info(f"Message: {message}")
+        if not message:
+            raise EntityUpdateException(f"Request to send Slack message missing message text.")
+        try:
+            post_to_slack_notify(self.token, message, channel)
+        except Exception as e:
+            raise EntityUpdateException(f"No Slack message sent. Encountered error: {e}")

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -264,15 +264,17 @@ class StatusChanger(EntityUpdater):
 
     def call_message_managers(self):
         for message_type in self.message_classes:
-            message_class = message_type(
+            message_manager = message_type(
                 self.status, self.uuid, self.token, msg=self.data_ingest_board_msg
             )
-            if message_class.is_valid_for_status:
+            if message_manager.is_valid_for_status:
                 try:
-                    message_class.update()
+                    message_manager.update()
                 except EntityUpdateException as e:
                     # Do not blow up for known errors
-                    logging.error(f"Message not sent for {message_class.__name__}. Error: {e}")
+                    logging.error(
+                        f"Message not sent for {message_manager.message_class.name}. Error: {e}"
+                    )
 
     def validate_fields_to_change(self):
         super().validate_fields_to_change()

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -268,7 +268,11 @@ class StatusChanger(EntityUpdater):
                 self.status, self.uuid, self.token, msg=self.data_ingest_board_msg
             )
             if message_class.is_valid_for_status:
-                message_class.update()
+                try:
+                    message_class.update()
+                except EntityUpdateException as e:
+                    # Do not blow up for known errors
+                    logging.error(f"Message not sent for {message_class.__name__}. Error: {e}")
 
     def validate_fields_to_change(self):
         super().validate_fields_to_change()

--- a/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
@@ -87,6 +87,19 @@ ENTITY_STATUS_MAP = {
     },
 }
 
+slack_channels = {
+    "base": "C08V3TAP3GQ",  # testing-status-change
+    "dataset_error": "C08V3TAP3GQ",
+    "dataset_invalid": "C08V3TAP3GQ",
+    "dataset_qa": "C099KMKJT26",  # dataset-qa-notifications
+    "upload_error": "C08V3TAP3GQ",
+    "upload_invalid": "C08V3TAP3GQ",
+    "upload_reorganized": "C08V3TAP3GQ",
+    "upload_priority_reorganized": "C08STFJTJKT",  # fasttrack-ingest
+}
+
+slack_channels_testing = {"base": "C08V3TAP3GQ"}
+
 
 # This is simplified from pythonop_get_dataset_state in utils
 def get_submission_context(token: str, uuid: str) -> dict[str, Any]:
@@ -217,3 +230,11 @@ def put_request_to_entity_api(
     response = http_hook.run(endpoint, json.dumps(update_fields), headers)
     logging.info(f"""Response: {response.json()}""")
     return response.json()
+
+
+def get_env():
+    from utils import find_matching_endpoint
+
+    if host := HttpHook.get_connection("entity_api_connection").host:
+        return find_matching_endpoint(host)
+    logging.error(f"Could not determine env. Host: {host}.")

--- a/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_utils.py
@@ -232,7 +232,7 @@ def put_request_to_entity_api(
     return response.json()
 
 
-def get_env():
+def get_env() -> Optional[str]:
     from utils import find_matching_endpoint
 
     if host := HttpHook.get_connection("entity_api_connection").host:


### PR DESCRIPTION
- Moved Slack channels from `airflow_conf` to `status_utils.py`, no Airflow restart required to make adjustments
     - Dedicated `slack_channels_testing` dict for use in non-prod environments
- Better error handling
     - Handling case where channel is not found for a given status
     - Very readily default to base channel
     - Prevent known exceptions in message managers (i.e. instances of `EntityUpdateException`) from causing task failure in Airflow  **(this most directly addresses the issues raised most recently)**
- Tests (find channel by env, use default if channel not found)