### PR TITLE
Refactored pythonop_send_create_dataset

### DIFF
--- a/src/ingest-pipeline/airflow/dags/status_change/email_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/email_manager.py
@@ -20,10 +20,7 @@ class EmailManager(MessageManager):
     cc = []
     subj = ""
     msg = ""
-    good_statuses = [
-        Statuses.DATASET_QA,
-        Statuses.UPLOAD_VALID,
-    ]
+    good_statuses = [Statuses.DATASET_QA, Statuses.UPLOAD_VALID, Statuses.PUBLICATION_QA]
 
     def __init__(
         self,

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -27,7 +27,6 @@ from typing import (
 )
 
 import cwltool  # used to find its path
-import requests
 import yaml
 from cryptography.fernet import Fernet
 from requests import codes
@@ -870,8 +869,6 @@ def make_httphook_request(
     method: str = "GET",
     payload: dict | None = None,
     headers: dict | None = None,
-    return_text_response: bool = False,
-    log: bool = True,
 ) -> dict:
     assert token or headers, "Must pass in either a token or header dict"
     if not headers:
@@ -894,18 +891,19 @@ def make_httphook_request(
         raise RuntimeError(f"misc error {e} on {endpoint}")
     try:
         response_json = response.json()
-        if log:
-            print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
+        print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
+        if content_len := response.get("Content-Length"):
+            if int(content_len) > 500000:  # length chosen arbitrarily, feel free to change
+                print(f"Response too long, not logging.")
+        else:
             print(response_json)
         return response_json
     except JSONDecodeError as e:
-        # Will raise unless response has `text` property and `return_text_response=True` (non-default)
+        # Will raise unless response has `text` property
         if response.text:
             print(
                 f"Received non-JSON response. Text: {response.text}; content: {response.content}"
             )
-            if return_text_response:
-                return response.text
         raise
 
 
@@ -1142,7 +1140,7 @@ def pythonop_get_dataset_state(**kwargs) -> dict:
     auth_tok = get_auth_tok(**kwargs)
 
     try:
-        ds_rslt = get_submission_context(auth_tok, uuid, log=False)
+        ds_rslt = get_submission_context(auth_tok, uuid)
     except Exception:
         return {}
 
@@ -1993,32 +1991,17 @@ def env_appropriate_slack_channel(prod_channel: str) -> str:
     return "C0A8ES4M9RU"  # test-notifications
 
 
-def get_submission_context(
-    token: str, uuid: str, headers: dict | None = None, log: bool = True
-) -> dict[str, Any]:
+def get_submission_context(token: str, uuid: str, headers: dict | None = None) -> dict[str, Any]:
     """
     Get info about an entity as returned by entity-api.
     uuid can also be a HuBMAP/SenNet ID.
     """
-    context = make_httphook_request(
+    return make_httphook_request(
         f"entities/{uuid}?exclude=direct_ancestors.files",
         "entity_api_connection",
         token,
         headers=headers,
-        log=log,
-        return_text_response=True,
     )
-    if type(context) is dict:
-        return context
-    # Edge case: if the metadata response is too large, entity-api will send a
-    # message with a link to the full metadata; try to follow that link and
-    # return response; this WILL add a good amount of processing time
-    elif type(context) is str and "hm-api-responses" in context:
-        print(f"Trying redirect URL ('{context}') from message body...")
-        redir_response = requests.get(context)
-        redir_response.raise_for_status()
-        return redir_response.json()
-    raise Exception(f"GET request to entity-api for {uuid} failed!")
 
 
 def get_config_value_int_recipients() -> list[str]:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -31,9 +31,10 @@ from typing import (
 )
 
 import cwltool  # used to find its path
+import requests
 import yaml
 from cryptography.fernet import Fernet
-from requests import codes
+from requests import JSONDecodeError, codes
 from requests.exceptions import HTTPError
 from schema_utils import (
     JSONType,
@@ -874,6 +875,36 @@ def get_auth_tok(**kwargs) -> str:
     return auth_tok
 
 
+def make_httphook_request(
+    endpoint: str, http_conn_id: str, token: str, method: str = "GET"
+) -> dict:
+    headers = {
+        "authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        "X-Hubmap-Application": "ingest-pipeline",
+    }
+
+    try:
+        response = HttpHook(method, http_conn_id=http_conn_id).run(
+            endpoint=endpoint, headers=headers
+        )
+        response.raise_for_status()
+        response_json = response.json()
+    except HTTPError as e:
+        print(f"ERROR: {e}")
+        if e.response.status_code == codes.unauthorized:
+            raise RuntimeError(f"authorization for {endpoint} was rejected?")
+        raise RuntimeError(f"misc error {e} on {endpoint}")
+    except JSONDecodeError as e:
+        if e.response:
+            print(
+                f"Received non-JSON response. Text: {e.response.text}; content: {e.response.content}"
+            )
+        raise
+
+    return response_json
+
+
 def pythonop_send_create_dataset(**kwargs) -> str:
     """
     Requests creation of a new dataset.  Returns dataset info via XCOM
@@ -907,127 +938,106 @@ def pythonop_send_create_dataset(**kwargs) -> str:
     for arg_options in [["pipeline_shorthand", "dataset_type_callable"]]:
         assert any(arg in kwargs for arg in arg_options)
 
-    http_conn_id = kwargs["http_conn_id"]
-    # ctx = kwargs['dag_run'].conf
-    headers = {
-        "authorization": "Bearer " + get_auth_tok(**kwargs),
-        "content-type": "application/json",
-        "X-Hubmap-Application": "ingest-pipeline",
-    }
-
     source_uuids = kwargs["parent_dataset_uuid_callable"](**kwargs)
     if not isinstance(source_uuids, list):
         source_uuids = [source_uuids]
 
     dataset_name = kwargs["dataset_name_callable"](**kwargs)
     endpoint = f"entities/{source_uuids[0]}?exclude=direct_ancestors.files"
+    token = get_auth_tok(**kwargs)
+    http_conn_id = kwargs["http_conn_id"]
 
     try:
-        previous_revision_path = None
-        response = HttpHook("GET", http_conn_id=http_conn_id).run(
-            endpoint=endpoint,
-            headers=headers,
-            extra_options={"check_response": False},
-        )
-        response.raise_for_status()
-        response_json = response.json()
-        if "group_uuid" not in response_json:
-            print(f"response from GET on entities{source_uuids[0]}:")
-            pprint(response_json)
-            raise ValueError("entities response did not contain group_uuid")
-
-        if "dataset_type" not in response_json:
-            print(f"response from GET on entities{source_uuids[0]}:")
-            pprint(response_json)
-            raise ValueError("entities response did not contain dataset_type")
-
-        parent_group_uuid = response_json["group_uuid"]
-        # Grab the dataset_type from the first_uuid
-        parent_dataset_type = response_json["dataset_type"]
-
-        if "pipeline_shorthand" in kwargs:
-            dataset_type = f"{parent_dataset_type} [{kwargs['pipeline_shorthand']}]"
+        response_json = make_httphook_request(endpoint, http_conn_id, token)
+        print(f"response from GET on entities{source_uuids[0]}:")
+        print(response_json)
+    except JSONDecodeError as e:
+        if e.response and "message:https" in e.response.text:
+            try:
+                url = e.response.text.split("message:http")[-1:][0]
+                response = requests.get(url)
+                response.raise_for_status()
+                response_json = response.json()
+            except Exception:
+                print("Request failed, unable to retrieve parent dataset info.")
+                raise
         else:
-            dataset_type = kwargs["dataset_type_callable"](**kwargs)
+            raise
 
-        creation_action = kwargs.get("creation_action", "Central Process")
+    if not (parent_group_uuid := response_json.get("group_uuid")):
+        raise ValueError("entities response did not contain group_uuid")
 
-        data = {
-            "direct_ancestor_uuids": source_uuids,
-            "dataset_info": dataset_name,
-            "dataset_type": dataset_type,
-            "group_uuid": parent_group_uuid,
-            "contains_human_genetic_sequences": False,
-            "creation_action": creation_action,
-        }
-        if "previous_revision_uuid_callable" in kwargs:
-            previous_revision_uuid = kwargs["previous_revision_uuid_callable"](**kwargs)
-            if previous_revision_uuid is not None:
-                data["previous_revision_uuid"] = previous_revision_uuid
-                revision_uuid = previous_revision_uuid
-            else:
-                revision_uuid = (
-                    kwargs["dag_run"].conf["parent_submission_id"][0]
-                    if isinstance(kwargs["dag_run"].conf["parent_submission_id"], list)
-                    else kwargs["dag_run"].conf["parent_submission_id"]
-                )
-            response = HttpHook("GET", http_conn_id=http_conn_id).run(
-                endpoint=f"datasets/{revision_uuid}/file-system-abs-path",
-                headers=headers,
-                extra_options={"check_response": False},
+    # Grab the dataset_type from the first_uuid
+    if not (parent_dataset_type := response_json.get("dataset_type")):
+        raise ValueError("entities response did not contain dataset_type")
+
+    if "pipeline_shorthand" in kwargs:
+        dataset_type = f"{parent_dataset_type} [{kwargs['pipeline_shorthand']}]"
+    else:
+        dataset_type = kwargs["dataset_type_callable"](**kwargs)
+
+    creation_action = kwargs.get("creation_action", "Central Process")
+
+    data = {
+        "direct_ancestor_uuids": source_uuids,
+        "dataset_info": dataset_name,
+        "dataset_type": dataset_type,
+        "group_uuid": parent_group_uuid,
+        "contains_human_genetic_sequences": False,
+        "creation_action": creation_action,
+    }
+
+    previous_revision_path = None
+    if "previous_revision_uuid_callable" in kwargs:
+        previous_revision_uuid = kwargs["previous_revision_uuid_callable"](**kwargs)
+        if previous_revision_uuid is not None:
+            data["previous_revision_uuid"] = previous_revision_uuid
+            revision_uuid = previous_revision_uuid
+        else:
+            revision_uuid = (
+                kwargs["dag_run"].conf["parent_submission_id"][0]
+                if isinstance(kwargs["dag_run"].conf["parent_submission_id"], list)
+                else kwargs["dag_run"].conf["parent_submission_id"]
             )
-            response.raise_for_status()
-            response_json = response.json()
-            if "path" not in response_json:
-                print(f"response from datasets/{revision_uuid}/file-system-abs-path:")
-                pprint(response_json)
-                raise ValueError(
-                    f"datasets/{revision_uuid}/file-system-abs-path did not return a path"
-                )
-            previous_revision_path = response_json["path"]
-
-        print("data for dataset creation:")
-        pprint(data)
-        response = HttpHook("POST", http_conn_id=http_conn_id).run(
-            endpoint="datasets", data=json.dumps(data), headers=headers, extra_options={}
+        response_json = make_httphook_request(
+            f"datasets/{revision_uuid}/file-system-abs-path", http_conn_id, token
         )
-        response.raise_for_status()
-        response_json = response.json()
-        print("response to dataset creation:")
-        pprint(response_json)
-        for elt in ["uuid", "group_uuid"]:
-            if elt not in response_json:
-                raise ValueError(f"datasets response did not contain {elt}")
-        uuid = response_json["uuid"]
-        group_uuid = response_json["group_uuid"]
-
-        # Send confirmation message that derived dataset has been created
-        call_message_managers(
-            response_json.get("status"),
-            uuid,
-            get_auth_tok(**kwargs),
-            messages={"run_id": kwargs.get("run_id", ""), "parent_dataset_uuid": source_uuids[0]},
-            message_classes=["SlackManager"],
-        )
-
-        response = HttpHook("GET", http_conn_id=http_conn_id).run(
-            endpoint=f"datasets/{uuid}/file-system-abs-path",
-            headers=headers,
-            extra_options={"check_response": False},
-        )
-        response.raise_for_status()
-        response_json = response.json()
         if "path" not in response_json:
-            print(f"response from datasets/{uuid}/file-system-abs-path:")
+            print(f"response from datasets/{revision_uuid}/file-system-abs-path:")
             pprint(response_json)
-            raise ValueError(f"datasets/{uuid}/file-system-abs-path" " did not return a path")
-        abs_path = response_json["path"]
+            raise ValueError(
+                f"datasets/{revision_uuid}/file-system-abs-path did not return a path"
+            )
+        previous_revision_path = response_json["path"]
 
-    except HTTPError as e:
-        print(f"ERROR: {e}")
-        if e.response.status_code == codes.unauthorized:
-            raise RuntimeError(f"authorization for {endpoint} was rejected?")
-        raise RuntimeError(f"misc error {e} on {endpoint}")
+    print("data for dataset creation:")
+    pprint(data)
+    response_json = make_httphook_request("datasets", http_conn_id, token, "POST")
+    print("response to dataset creation:")
+    pprint(response_json)
+    for elt in ["uuid", "group_uuid"]:
+        if elt not in response_json:
+            raise ValueError(f"datasets response did not contain {elt}")
+    uuid = response_json["uuid"]
+    group_uuid = response_json["group_uuid"]
+
+    # Send confirmation message that derived dataset has been created
+    call_message_managers(
+        response_json["status"],
+        uuid,
+        get_auth_tok(**kwargs),
+        messages={"run_id": kwargs.get("run_id", ""), "parent_dataset_uuid": source_uuids[0]},
+        message_classes=["SlackManager"],
+    )
+
+    response_json = make_httphook_request(
+        f"datasets/{uuid}/file-system-abs-path", http_conn_id, token
+    )
+    if "path" not in response_json:
+        print(f"response from datasets/{uuid}/file-system-abs-path:")
+        pprint(response_json)
+        raise ValueError(f"datasets/{uuid}/file-system-abs-path" " did not return a path")
+    abs_path = response_json["path"]
 
     kwargs["ti"].xcom_push(key="group_uuid", value=group_uuid)
     kwargs["ti"].xcom_push(key="derived_dataset_uuid", value=uuid)

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -876,7 +876,7 @@ def make_httphook_request(
     method: str = "GET",
     payload: dict | None = None,
     headers: dict | None = None,
-    log: bool = False,
+    return_text_response: bool = False,
 ) -> dict:
     assert token or headers, "Must pass in either a token or header dict"
     if not headers:
@@ -888,7 +888,7 @@ def make_httphook_request(
     http_hook = HttpHook(method, http_conn_id=http_conn_id)
     run_args = {"endpoint": endpoint, "headers": headers}
     if method.lower() == "post":
-        run_args["payload"] = json.dumps(payload)
+        run_args["data"] = json.dumps(payload)
     try:
         response = http_hook.run(**run_args)
         response.raise_for_status()
@@ -899,27 +899,16 @@ def make_httphook_request(
         raise RuntimeError(f"misc error {e} on {endpoint}")
     try:
         response_json = response.json()
-        if log:
-            print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
-            print(response_json)
+        print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
+        print(response_json)
         return response_json
     except JSONDecodeError as e:
         if response.text:
             print(
                 f"Received non-JSON response. Text: {response.text}; content: {response.content}"
             )
-            # Edge case: if the metadata response is too large, ingest_api will send a
-            # link to the full content in the text body of the response; try to follow
-            # that (do not log it, it's too large!!)
-            if "message:https" in response.text:
-                try:
-                    url = response.text.split("message:")[-1:][0]
-                    print(f"Trying redirect URL ('{url}') from message body...")
-                    redir_response = requests.get(url)
-                    redir_response.raise_for_status()
-                    return redir_response.json()
-                except Exception:
-                    print("Redirect request failed.")
+            if return_text_response:
+                return response.text
         raise
 
 
@@ -990,9 +979,21 @@ def pythonop_send_create_dataset(**kwargs) -> str:
     # get previous_revision_path and previous_revision_uuid (if applicable)
     previous_revision_path = None
     if "previous_revision_uuid_callable" in kwargs:
-        previous_revision_uuid, previous_revision_path = get_previous_revision_values(
-            http_conn_id, token, **kwargs
+        if previous_revision_uuid := kwargs["previous_revision_uuid_callable"](**kwargs):
+            revision_uuid = previous_revision_uuid
+        else:
+            revision_uuid = (
+                kwargs["dag_run"].conf["parent_submission_id"][0]
+                if isinstance(kwargs["dag_run"].conf["parent_submission_id"], list)
+                else kwargs["dag_run"].conf["parent_submission_id"]
+            )
+        response_json = make_httphook_request(
+            f"datasets/{revision_uuid}/file-system-abs-path", http_conn_id, token
         )
+        if not (previous_revision_path := response_json.get("path")):
+            raise ValueError(
+                f"datasets/{revision_uuid}/file-system-abs-path did not return a path"
+            )
         data["previous_revision_uuid"] = previous_revision_uuid
 
     # create dataset
@@ -1000,7 +1001,7 @@ def pythonop_send_create_dataset(**kwargs) -> str:
     pprint(data)
     print("creating dataset...")
     response_json = make_httphook_request(
-        "datasets", http_conn_id, token, method="POST", payload=data, log=True
+        "datasets", http_conn_id, token, method="POST", payload=data
     )
 
     for elt in ["uuid", "group_uuid"]:
@@ -1025,29 +1026,12 @@ def pythonop_send_create_dataset(**kwargs) -> str:
 
     # get and return abs_path of new dataset
     response_json = make_httphook_request(
-        f"datasets/{uuid}/file-system-abs-path", http_conn_id, token, log=True
+        f"datasets/{uuid}/file-system-abs-path", http_conn_id, token
     )
     if not (abs_path := response_json.get("path")):
         raise ValueError(f"datasets/{uuid}/file-system-abs-path" " did not return a path")
 
     return abs_path
-
-
-def get_previous_revision_values(http_conn_id, token, **kwargs) -> tuple[str, str]:
-    if previous_revision_uuid := kwargs["previous_revision_uuid_callable"](**kwargs):
-        revision_uuid = previous_revision_uuid
-    else:
-        revision_uuid = (
-            kwargs["dag_run"].conf["parent_submission_id"][0]
-            if isinstance(kwargs["dag_run"].conf["parent_submission_id"], list)
-            else kwargs["dag_run"].conf["parent_submission_id"]
-        )
-    response_json = make_httphook_request(
-        f"datasets/{revision_uuid}/file-system-abs-path", http_conn_id, token
-    )
-    if not (previous_revision_path := response_json.get("path")):
-        raise ValueError(f"datasets/{revision_uuid}/file-system-abs-path did not return a path")
-    return previous_revision_uuid, previous_revision_path
 
 
 def pythonop_set_dataset_state(**kwargs) -> None:
@@ -1222,7 +1206,7 @@ def pythonop_get_dataset_state(**kwargs) -> dict:
 
         try:
             organs_query_rslt = make_httphook_request(
-                f"datasets/{ds_rslt['uuid']}/organs", "entity_api_connection", auth_tok, log=True
+                f"datasets/{ds_rslt['uuid']}/organs", "entity_api_connection", auth_tok
             )
             rslt["organs"] = [entry["organ"] for entry in organs_query_rslt]
         except Exception:
@@ -1966,7 +1950,7 @@ def get_soft_data(dataset_uuid, **kwargs) -> dict:
     """
     print("Fetching rule_set response...")
     return make_httphook_request(
-        f"/assaytype/{dataset_uuid}", "ingest_api_connection", get_auth_tok(**kwargs), log=True
+        f"/assaytype/{dataset_uuid}", "ingest_api_connection", get_auth_tok(**kwargs)
     )
 
 
@@ -1988,7 +1972,7 @@ def gather_calculated_metadata(**kwargs):
 def post_to_slack_notify(token: str, message: str, channel: str):
     payload = {"message": message, "channel": channel}
     return make_httphook_request(
-        "/notify", "ingest_api_connection", token, method="POST", payload=payload, log=True
+        "/notify", "ingest_api_connection", token, method="POST", payload=payload
     )
 
 
@@ -2016,12 +2000,31 @@ def get_submission_context(token: str, uuid: str, headers: dict | None = None) -
     Get info about an entity as returned by ingest_api.
     uuid can also be a HuBMAP/SenNet ID.
     """
-    return make_httphook_request(
-        f"entities/{uuid}?exclude=direct_ancestors.files",
-        "ingest_api_connection",
-        token,
-        headers=headers,
-    )
+    try:
+        return make_httphook_request(
+            f"entities/{uuid}?exclude=direct_ancestors.files",
+            "ingest_api_connection",
+            token,
+            headers=headers,
+        )
+    except JSONDecodeError:
+        # Edge case: if the metadata response is too large, ingest API will send a
+        # message including the link to the full metadata, but as part of longer message;
+        # call entity API directly to get just the link, follow it, and try to return response
+        entity_api_response = make_httphook_request(
+            f"entities/{uuid}",
+            "entity_api_connection",
+            token,
+            headers=headers,
+            return_text_response=True,
+        )
+        if type(entity_api_response) is str and entity_api_response.startswith("http"):
+            url = entity_api_response.text
+            print(f"Trying redirect URL ('{url}') from message body...")
+            redir_response = requests.get(url)
+            redir_response.raise_for_status()
+            return redir_response.json()
+        raise
 
 
 def main():

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -871,6 +871,7 @@ def make_httphook_request(
     payload: dict | None = None,
     headers: dict | None = None,
     return_text_response: bool = False,
+    log: bool = True,
 ) -> dict:
     assert token or headers, "Must pass in either a token or header dict"
     if not headers:
@@ -893,8 +894,9 @@ def make_httphook_request(
         raise RuntimeError(f"misc error {e} on {endpoint}")
     try:
         response_json = response.json()
-        print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
-        print(response_json)
+        if log:
+            print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
+            print(response_json)
         return response_json
     except JSONDecodeError as e:
         if response.text:
@@ -1139,7 +1141,7 @@ def pythonop_get_dataset_state(**kwargs) -> dict:
     auth_tok = get_auth_tok(**kwargs)
 
     try:
-        ds_rslt = get_submission_context(auth_tok, uuid)
+        ds_rslt = get_submission_context(auth_tok, uuid, log=False)
     except Exception:
         return {}
 
@@ -1990,7 +1992,9 @@ def env_appropriate_slack_channel(prod_channel: str) -> str:
     return "C0A8ES4M9RU"  # test-notifications
 
 
-def get_submission_context(token: str, uuid: str, headers: dict | None = None) -> dict[str, Any]:
+def get_submission_context(
+    token: str, uuid: str, headers: dict | None = None, log: bool = True
+) -> dict[str, Any]:
     """
     Get info about an entity as returned by ingest_api.
     uuid can also be a HuBMAP/SenNet ID.
@@ -2001,6 +2005,7 @@ def get_submission_context(token: str, uuid: str, headers: dict | None = None) -
             "ingest_api_connection",
             token,
             headers=headers,
+            log=log,
         )
     except JSONDecodeError:
         # Edge case: if the metadata response is too large, ingest API will send a

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -2004,13 +2004,16 @@ def env_appropriate_slack_channel(prod_channel: str) -> str:
     return "C0A8ES4M9RU"  # test-notifications
 
 
-def get_submission_context(token: str, uuid: str) -> dict[str, Any]:
+def get_submission_context(token: str, uuid: str, headers: dict | None = None) -> dict[str, Any]:
     """
     uuid can also be a HuBMAP/SenNet ID.
     """
     try:
         return make_httphook_request(
-            f"entities/{uuid}?exclude=direct_ancestors.files", "entity_api_connection", token
+            f"entities/{uuid}?exclude=direct_ancestors.files",
+            "entity_api_connection",
+            token,
+            headers=headers,
         )
     except JSONDecodeError as e:
         # Edge case: if the metadata response is too large, ingest_api will send a

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -19,15 +19,11 @@ from textwrap import dedent
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
-    List,
     Mapping,
-    Optional,
     Pattern,
     Tuple,
     TypeVar,
-    Union,
 )
 
 import cwltool  # used to find its path
@@ -37,21 +33,18 @@ from cryptography.fernet import Fernet
 from requests import JSONDecodeError, codes
 from requests.exceptions import HTTPError
 from schema_utils import (
-    JSONType,
-)
-from schema_utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,
 )
 
 from airflow import DAG
 from airflow.configuration import conf as airflow_conf
-from airflow.models.baseoperator import BaseOperator
+from airflow.models import Operator
 from airflow.providers.http.hooks.http import HttpHook
 from airflow.utils.email import send_email as airflow_send_email
 
 airflow_conf.read(join(environ["AIRFLOW_HOME"], "instance", "app.cfg"))
 try:
-    sys.path.append(airflow_conf.as_dict()["connections"]["SRC_PATH"].strip("'").strip('"'))
+    sys.path.append(str(airflow_conf.as_dict()["connections"]["SRC_PATH"]).strip("'").strip('"'))
     from misc.tools.survey import ENDPOINTS
 
     sys.path.pop()
@@ -59,10 +52,10 @@ except Exception:
     ENDPOINTS = {}
 
 
-# Some functions accept a `str` or `List[str]` and return that same type
-StrOrListStr = TypeVar("StrOrListStr", str, List[str])
+# Some functions accept a `str` or `list[str]` and return that same type
+StrOrListStr = TypeVar("StrOrListStr", str, list[str])
 
-PathStrOrList = Union[str, Path, Iterable[Union[str, Path]]]
+PathStrOrList = str | Path | Iterable[str | Path]
 
 # Some constants
 PIPELINE_BASE_DIR = Path(__file__).resolve().parent / "cwl"
@@ -106,21 +99,23 @@ FILE_TYPE_MATCHERS = [
     (r"(^.*\.yml$)|(^.*\.yaml$)", "yaml"),
     (r"^.*\.zip$", "zip"),
 ]
-COMPILED_TYPE_MATCHERS: Optional[List[Tuple[Pattern, str]]] = None
+COMPILED_TYPE_MATCHERS: list[Tuple[Pattern, str]] | None = None
 
 """
 Lazy construction: a list of tuples (collection_type_regex, assay_type_regex, workflow)
 """
 WORKFLOW_MAP_FILENAME = "workflow_map.yml"  # Expected to be found in this same dir
 WORKFLOW_MAP_SCHEMA = "workflow_map_schema.yml"
-COMPILED_WORKFLOW_MAP: Optional[List[Tuple[Pattern, Pattern, str]]] = None
+COMPILED_WORKFLOW_MAP: list[Tuple[Pattern, Pattern, str]] | None = None
 
 """
 Lazy construction; a list of tuples (dag_id_reges, task_id_regex, {key:value})
 """
 RESOURCE_MAP_FILENAME = "resource_map.yml"  # Expected to be found in this same dir
 RESOURCE_MAP_SCHEMA = "resource_map_schema.yml"
-COMPILED_RESOURCE_MAP: Optional[List[Tuple[Pattern, int, Dict[str, Any]]]] = None
+TaskList = list[tuple[Pattern, dict[str, Any]]]
+DagDct = dict[str, Any]
+COMPILED_RESOURCE_MAP: list[Tuple[Pattern, DagDct, TaskList]] | None = None
 
 CURATION_CONTACTS = ["bhonick@psc.edu", "dbordelon@psc.edu", "egaskin@psc.edu"]
 CURATION_OFFICE_HOURS_SCHEDULING_LINK = "https://calendar.app.google/db2J6CDzZQuQnGHr6"
@@ -135,10 +130,10 @@ SequencingDagParameters = namedtuple(
 # TODO: rethink this, now that it's getting more and more unwieldy
 ManifestMatch = Tuple[
     bool,
-    Optional[str],
-    Optional[str],
-    Optional[bool],
-    Optional[bool],
+    str | None,
+    str | None,
+    bool | None,
+    bool | None,
 ]
 
 
@@ -155,7 +150,7 @@ class FileMatcher(ABC):
 
 class PipelineFileMatcher(FileMatcher):
     # (file/directory regex, description template, EDAM ontology term, is_qa_qc, is_data_product)
-    matchers: List[Tuple[Pattern, str, str, bool, bool]]
+    matchers: list[Tuple[Pattern, str, str, bool, bool]]
 
     def __init__(self):
         self.matchers = []
@@ -211,6 +206,7 @@ class DummyFileMatcher(FileMatcher):
     """
 
     def get_file_metadata(self, file_path: Path) -> ManifestMatch:
+        del file_path
         return True, "", "", False, False
 
 
@@ -230,7 +226,7 @@ class HMDAG(DAG):
             kwargs["max_active_runs"] = get_lanes_resource(dag_id)
         super().__init__(dag_id, **kwargs)
 
-    def add_task(self, task: BaseOperator):
+    def add_task(self, task: Operator):
         """
         Provide "queue".  This overwrites existing data on the fly
         unless the queue specified in the resource table is None.
@@ -250,7 +246,7 @@ class HMDAG(DAG):
         super().add_task(task)
 
 
-def find_pipeline_manifests(cwl_files: Union[List[Path], List[Dict], str]) -> List[Path]:
+def find_pipeline_manifests(cwl_files: list[Path] | list[dict] | str) -> list[Path]:
     """
     Constructs manifest paths from CWL files (strip '.cwl', append
     '-manifest.json'), and check whether each manifest exists. Return
@@ -271,13 +267,13 @@ def find_pipeline_manifests(cwl_files: Union[List[Path], List[Dict], str]) -> Li
 
 
 def get_cwl_cmd_from_workflows(
-    workflows: List[Dict],
+    workflows: list[dict],
     workflow_index: int,
-    input_param_vals: List,
+    input_param_vals: list,
     tmp_dir: Path,
     ti,
-    cwl_param_vals: Optional[List[Dict]] = None,
-) -> List:
+    cwl_param_vals: list[dict] | None = None,
+) -> list:
     """
     :param workflows: Iterable of workflow dictionaries
     :param workflow_index: index of workflow to build
@@ -309,7 +305,7 @@ def get_cwl_cmd_from_workflows(
     if not outdir_present:
         command.extend(["--outdir", str(tmp_dir / "cwl_out")])
 
-    command.append(Path(workflow["workflow_path"]))
+    command.append(workflow["workflow_path"])
 
     # Extend the command with the input parameters
     for param in workflow["input_parameters"]:
@@ -330,7 +326,7 @@ def get_absolute_workflow(workflow: Path) -> Path:
     return PIPELINE_BASE_DIR / workflow
 
 
-def get_absolute_workflows(*workflows: Path) -> List[Path]:
+def get_absolute_workflows(*workflows: Path) -> list[Path]:
     """
     :param workflows: iterable of `Path`s to CWL files, absolute
       or relative
@@ -341,7 +337,7 @@ def get_absolute_workflows(*workflows: Path) -> List[Path]:
     return [get_absolute_workflow(workflow) for workflow in workflows]
 
 
-def get_named_absolute_workflows(**workflow_kwargs: Path) -> Dict[str, Path]:
+def get_named_absolute_workflows(**workflow_kwargs: Path) -> dict[str, Path]:
     # The type hint for **workflow_kwargs looks a little odd, but
     # apparently this is how you specify that all values are of that
     # type -- the keys of that dict are necessarily strings
@@ -360,12 +356,14 @@ def build_dataset_name(dag_id: str, pipeline_str: str, **kwargs) -> str:
     return f"{dag_id}__{parent_submission_str}__{pipeline_str}"
 
 
-def get_parent_dataset_uuids_list(**kwargs) -> List[str]:
-    uuid_list = kwargs["dag_run"].conf["parent_submission_id"]
+def get_parent_dataset_uuids_list(**kwargs) -> list[str]:
+    parent_uuid_list = kwargs["dag_run"].conf["parent_submission_id"]
+    azimuth_uuid_list = None
     if kwargs["dag"].dag_id == "azimuth_annotations":
-        uuid_list = pythonop_get_dataset_state(
-            dataset_uuid_callable=lambda **kwargs: uuid_list[0], **kwargs
+        azimuth_uuid_list = pythonop_get_dataset_state(
+            dataset_uuid_callable=lambda **_: parent_uuid_list[0], **kwargs
         ).get("parent_dataset_uuid_list")
+    uuid_list = azimuth_uuid_list if azimuth_uuid_list else parent_uuid_list
     if not isinstance(uuid_list, list):
         uuid_list = [uuid_list]
     return uuid_list
@@ -380,7 +378,7 @@ def get_parent_dataset_uuid(**kwargs) -> str:
 def get_dataset_type_organ_based(**kwargs) -> str:
     dataset_uuid = get_parent_dataset_uuid(**kwargs)
 
-    def my_callable(**kwargs):
+    def my_callable(**_):
         return dataset_uuid
 
     ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=my_callable, **kwargs)
@@ -397,13 +395,13 @@ def get_dataset_type_organ_based(**kwargs) -> str:
     return f"{ds_rslt['dataset_type']} [{pipeline_shorthand}]"
 
 
-def get_dataset_type_previous_version(**kwargs) -> List[str]:
+def get_dataset_type_previous_version(**kwargs) -> list[str]:
     dataset_uuid = get_previous_revision_uuid(**kwargs)
     if dataset_uuid is None:
         dataset_uuid = kwargs["dag_run"].conf.get("parent_submission_id", [None])[0]
     assert dataset_uuid is not None, "Missing previous_version_uuid"
 
-    def my_callable(**kwargs):
+    def my_callable(**_):
         return dataset_uuid
 
     ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=my_callable, **kwargs)
@@ -420,7 +418,7 @@ def get_dataname_previous_version(**kwargs) -> str:
         dataset_uuid = kwargs["dag_run"].conf.get("parent_submission_id", [None])[0]
     assert dataset_uuid is not None, "Missing previous_version_uuid"
 
-    def my_callable(**kwargs):
+    def my_callable(**_):
         return dataset_uuid
 
     ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=my_callable, **kwargs)
@@ -431,7 +429,7 @@ def get_dataname_previous_version(**kwargs) -> str:
     return ds_rslt["dataset_info"]
 
 
-def get_assay_previous_version(**kwargs) -> tuple:
+def get_assay_previous_version(**kwargs) -> tuple[str, str, str, int] | None:
     """Returns information based on previous run to indicate how the re-annotation should process:
     position 1: Assay indicator for pipeline decision
     position 2: Matrix file
@@ -458,7 +456,7 @@ def get_assay_previous_version(**kwargs) -> tuple:
         return "snareseq", "mudata_raw.h5mu", "secondary_analysis.h5mu", 1
 
 
-def get_parent_dataset_paths_list(**kwargs) -> List[Path]:
+def get_parent_dataset_paths_list(**kwargs) -> list[Path]:
     path_list = kwargs["dag_run"].conf["parent_lz_path"]
     if not isinstance(path_list, list):
         path_list = [path_list]
@@ -471,7 +469,7 @@ def get_parent_dataset_path(**kwargs) -> Path:
     return path_set.pop()
 
 
-def get_parent_data_dirs_list(**kwargs) -> List[Path]:
+def get_parent_data_dirs_list(**kwargs) -> list[Path]:
     """
     Build the absolute paths to the data, including the data_path offsets from
     the parent datasets' metadata
@@ -496,7 +494,7 @@ def get_parent_data_dir(**kwargs) -> Path:
     return path_set.pop()
 
 
-def get_previous_revision_uuid(**kwargs) -> Optional[str]:
+def get_previous_revision_uuid(**kwargs) -> str | None:
     return kwargs["dag_run"].conf.get("previous_version_uuid", None)
 
 
@@ -504,7 +502,7 @@ def get_dataset_uuid(**kwargs) -> str:
     return kwargs["ti"].xcom_pull(key="derived_dataset_uuid", task_ids="send_create_dataset")
 
 
-def get_uuid_for_error(**kwargs) -> Optional[str]:
+def get_uuid_for_error(**kwargs) -> str | None:
     """
     Return the uuid for the derived dataset if it exists, and of the parent dataset otherwise.
     """
@@ -524,11 +522,10 @@ def get_git_commits(file_list: StrOrListStr) -> StrOrListStr:
     """
     rslt = []
     if isinstance(file_list, str):  # sadly, a str is an Iterable[str]
-        file_list = [file_list]
-        unroll = True
+        cleaned_file_list = [file_list]
     else:
-        unroll = False
-    for fname in file_list:
+        cleaned_file_list = file_list
+    for fname in cleaned_file_list:
         log_command = [piece.format(fname=fname) for piece in GIT_LOG_COMMAND]
         try:
             dirnm = dirname(fname)
@@ -541,10 +538,9 @@ def get_git_commits(file_list: StrOrListStr) -> StrOrListStr:
             line = line.encode("utf-8")
         hashval = line.split()[0].strip().decode("utf-8")
         rslt.append(hashval)
-    if unroll:
+    if isinstance(file_list, str):
         return rslt[0]
-    else:
-        return rslt
+    return rslt
 
 
 def _convert_git_to_proper_url(raw_url: str) -> str:
@@ -565,11 +561,10 @@ def get_git_origins(file_list: StrOrListStr) -> StrOrListStr:
     """
     rslt = []
     if isinstance(file_list, str):  # sadly, a str is an Iterable[str]
-        file_list = [file_list]
-        unroll = True
+        cleaned_file_list = [file_list]
     else:
-        unroll = False
-    for fname in file_list:
+        cleaned_file_list = file_list
+    for fname in cleaned_file_list:
         command = [piece.format(fname=fname) for piece in GIT_ORIGIN_COMMAND]
         try:
             dirnm = dirname(fname)
@@ -583,13 +578,12 @@ def get_git_origins(file_list: StrOrListStr) -> StrOrListStr:
         url = line.split()[0].strip().decode("utf-8")
         url = _convert_git_to_proper_url(url)
         rslt.append(url)
-    if unroll:
+    if isinstance(file_list, str):
         return rslt[0]
-    else:
-        return rslt
+    return rslt
 
 
-def get_git_root_paths(file_list: Iterable[str]) -> Union[str, List[str]]:
+def get_git_root_paths(file_list: Iterable[str]) -> str | list[str]:
     """
     Given a list of file paths, return a list of the root directories of the git
     working trees of the files.
@@ -628,7 +622,7 @@ def get_git_provenance_dict(file_list: PathStrOrList) -> Mapping[str, str]:
     return {basename(fname): get_git_commits(realpath(fname)) for fname in file_list}
 
 
-def get_git_provenance_list(file_list: Iterable[str]) -> List[Mapping[str, Any]]:
+def get_git_provenance_list(file_list: Iterable[str]) -> list[Mapping[str, Any]]:
     """
     Given a list of file paths, return a list of dicts of the form:
 
@@ -651,7 +645,7 @@ def get_git_provenance_list(file_list: Iterable[str]) -> List[Mapping[str, Any]]
 
         root = get_git_root_paths(fname)
         dag_prov_entry = {
-            "name": relpath(fname, root),
+            "name": relpath(fname, root if type(root) is str else root[0]),
             "hash": get_git_commits(realpath(fname)),
             "origin": get_git_origins(realpath(fname)),
             "version": get_pipeline_version(realpath(fname)),
@@ -668,7 +662,7 @@ def get_git_provenance_list(file_list: Iterable[str]) -> List[Mapping[str, Any]]
     return result
 
 
-def get_pipeline_version(path: str) -> str:
+def get_pipeline_version(path: str | Path) -> str:
     """
     Given a cwl file path, return the pipeline version
     First try to get the GIT version tag
@@ -689,7 +683,7 @@ def get_pipeline_version(path: str) -> str:
 
     # If no tag found, check the cwl file
     if path.suffix != ".cwl":
-        return pipeline_version
+        return str(pipeline_version)
 
     if pipeline_version == "":
         with open(path, "r") as file:
@@ -699,7 +693,7 @@ def get_pipeline_version(path: str) -> str:
             if isinstance(docker_info, str):
                 _, pipeline_version = docker_info.split(":")
 
-    return pipeline_version
+    return str(pipeline_version)
 
 
 def _get_file_type(path: Path) -> str:
@@ -719,7 +713,7 @@ def _get_file_type(path: Path) -> str:
     return "unknown"
 
 
-def get_file_metadata(root_dir: str, matcher: FileMatcher) -> List[Mapping[str, Any]]:
+def get_file_metadata(root_dir: str, matcher: FileMatcher) -> list[Mapping[str, Any]]:
     """
     Given a root directory, return a list of the form:
 
@@ -775,7 +769,7 @@ def get_file_metadata(root_dir: str, matcher: FileMatcher) -> List[Mapping[str, 
 def get_file_metadata_dict(
     root_dir: str,
     alt_file_dir: str,
-    pipeline_file_manifests: List[Path],
+    pipeline_file_manifests: list[Path],
     max_in_line_files: int = MAX_IN_LINE_FILES,
 ) -> Mapping[str, Any]:
     """
@@ -876,20 +870,37 @@ def get_auth_tok(**kwargs) -> str:
 
 
 def make_httphook_request(
-    endpoint: str, http_conn_id: str, token: str, method: str = "GET"
+    endpoint: str,
+    http_conn_id: str,
+    token: str | None,
+    method: str = "GET",
+    payload: dict | None = None,
+    headers: dict | None = None,
+    log: bool = False,
 ) -> dict:
-    headers = {
-        "authorization": f"Bearer {token}",
-        "content-type": "application/json",
-        "X-Hubmap-Application": "ingest-pipeline",
-    }
+    assert token or headers, "Must pass in either a token or header dict"
+    if not headers:
+        headers = {
+            "authorization": f"Bearer {token}",
+            "content-type": "application/json",
+            "X-Hubmap-Application": "ingest-pipeline",
+        }
 
     try:
-        response = HttpHook(method, http_conn_id=http_conn_id).run(
-            endpoint=endpoint, headers=headers
-        )
+        if method.lower() == "post":
+            response = HttpHook(method, http_conn_id=http_conn_id).run(
+                endpoint=endpoint, headers=headers, payload=json.dumps(payload)
+            )
+        else:
+            response = HttpHook(method, http_conn_id=http_conn_id).run(
+                endpoint=endpoint, headers=headers
+            )
         response.raise_for_status()
         response_json = response.json()
+        if log:
+            print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
+            print(response_json)
+        return response_json
     except HTTPError as e:
         print(f"ERROR: {e}")
         if e.response.status_code == codes.unauthorized:
@@ -901,8 +912,6 @@ def make_httphook_request(
                 f"Received non-JSON response. Text: {e.response.text}; content: {e.response.content}"
             )
         raise
-
-    return response_json
 
 
 def pythonop_send_create_dataset(**kwargs) -> str:
@@ -933,95 +942,65 @@ def pythonop_send_create_dataset(**kwargs) -> str:
     """
     from status_change.status_manager import call_message_managers
 
+    # check required values
     for arg in ["parent_dataset_uuid_callable", "http_conn_id"]:
         assert arg in kwargs, "missing required argument {}".format(arg)
     for arg_options in [["pipeline_shorthand", "dataset_type_callable"]]:
         assert any(arg in kwargs for arg in arg_options)
+    token = get_auth_tok(**kwargs)
+    http_conn_id = kwargs["http_conn_id"]
 
+    # get direct_ancestor_uuids
     source_uuids = kwargs["parent_dataset_uuid_callable"](**kwargs)
     if not isinstance(source_uuids, list):
         source_uuids = [source_uuids]
 
-    dataset_name = kwargs["dataset_name_callable"](**kwargs)
-    endpoint = f"entities/{source_uuids[0]}?exclude=direct_ancestors.files"
-    token = get_auth_tok(**kwargs)
-    http_conn_id = kwargs["http_conn_id"]
-
-    try:
-        response_json = make_httphook_request(endpoint, http_conn_id, token)
-        print(f"response from GET on entities{source_uuids[0]}:")
-        print(response_json)
-    except JSONDecodeError as e:
-        if e.response and "message:https" in e.response.text:
-            try:
-                url = e.response.text.split("message:http")[-1:][0]
-                response = requests.get(url)
-                response.raise_for_status()
-                response_json = response.json()
-            except Exception:
-                print("Request failed, unable to retrieve parent dataset info.")
-                raise
-        else:
-            raise
-
+    # get parent_dataset_type, parent_group_uuid
+    response_json = get_submission_context(token, source_uuids[0])
     if not (parent_group_uuid := response_json.get("group_uuid")):
         raise ValueError("entities response did not contain group_uuid")
-
-    # Grab the dataset_type from the first_uuid
     if not (parent_dataset_type := response_json.get("dataset_type")):
+        # Grab the dataset_type from the first_uuid
         raise ValueError("entities response did not contain dataset_type")
 
-    if "pipeline_shorthand" in kwargs:
-        dataset_type = f"{parent_dataset_type} [{kwargs['pipeline_shorthand']}]"
+    # get dataset_type
+    if pipeline_shorthand := kwargs.get("pipeline_shorthand"):
+        dataset_type = f"{parent_dataset_type} [{pipeline_shorthand}]"
     else:
         dataset_type = kwargs["dataset_type_callable"](**kwargs)
 
-    creation_action = kwargs.get("creation_action", "Central Process")
-
     data = {
         "direct_ancestor_uuids": source_uuids,
-        "dataset_info": dataset_name,
+        "dataset_info": kwargs["dataset_name_callable"](**kwargs),
         "dataset_type": dataset_type,
         "group_uuid": parent_group_uuid,
         "contains_human_genetic_sequences": False,
-        "creation_action": creation_action,
+        "creation_action": kwargs.get("creation_action", "Central Process"),
     }
 
+    # get previous_revision_path and previous_revision_uuid (if applicable)
     previous_revision_path = None
     if "previous_revision_uuid_callable" in kwargs:
-        previous_revision_uuid = kwargs["previous_revision_uuid_callable"](**kwargs)
-        if previous_revision_uuid is not None:
-            data["previous_revision_uuid"] = previous_revision_uuid
-            revision_uuid = previous_revision_uuid
-        else:
-            revision_uuid = (
-                kwargs["dag_run"].conf["parent_submission_id"][0]
-                if isinstance(kwargs["dag_run"].conf["parent_submission_id"], list)
-                else kwargs["dag_run"].conf["parent_submission_id"]
-            )
-        response_json = make_httphook_request(
-            f"datasets/{revision_uuid}/file-system-abs-path", http_conn_id, token
+        previous_revision_uuid, previous_revision_path = get_previous_revision_values(
+            http_conn_id, token, **kwargs
         )
-        if "path" not in response_json:
-            print(f"response from datasets/{revision_uuid}/file-system-abs-path:")
-            pprint(response_json)
-            raise ValueError(
-                f"datasets/{revision_uuid}/file-system-abs-path did not return a path"
-            )
-        previous_revision_path = response_json["path"]
+        data["previous_revision_uuid"] = previous_revision_uuid
 
+    # create dataset
     print("data for dataset creation:")
     pprint(data)
-    response_json = make_httphook_request("datasets", http_conn_id, token, "POST")
-    print("response to dataset creation:")
-    pprint(response_json)
+    print("creating dataset...")
+    response_json = make_httphook_request(
+        "datasets", http_conn_id, token, method="POST", payload=data, log=True
+    )
+
     for elt in ["uuid", "group_uuid"]:
         if elt not in response_json:
             raise ValueError(f"datasets response did not contain {elt}")
     uuid = response_json["uuid"]
     group_uuid = response_json["group_uuid"]
 
-    # Send confirmation message that derived dataset has been created
+    # send confirmation message that derived dataset has been created
     call_message_managers(
         response_json["status"],
         uuid,
@@ -1030,19 +1009,36 @@ def pythonop_send_create_dataset(**kwargs) -> str:
         message_classes=["SlackManager"],
     )
 
-    response_json = make_httphook_request(
-        f"datasets/{uuid}/file-system-abs-path", http_conn_id, token
-    )
-    if "path" not in response_json:
-        print(f"response from datasets/{uuid}/file-system-abs-path:")
-        pprint(response_json)
-        raise ValueError(f"datasets/{uuid}/file-system-abs-path" " did not return a path")
-    abs_path = response_json["path"]
-
+    # push values to xcom
     kwargs["ti"].xcom_push(key="group_uuid", value=group_uuid)
     kwargs["ti"].xcom_push(key="derived_dataset_uuid", value=uuid)
     kwargs["ti"].xcom_push(key="previous_revision_path", value=previous_revision_path)
+
+    # get and return abs_path of new dataset
+    response_json = make_httphook_request(
+        f"datasets/{uuid}/file-system-abs-path", http_conn_id, token, log=True
+    )
+    if not (abs_path := response_json.get("path")):
+        raise ValueError(f"datasets/{uuid}/file-system-abs-path" " did not return a path")
+
     return abs_path
+
+
+def get_previous_revision_values(http_conn_id, token, **kwargs) -> tuple[str, str]:
+    if previous_revision_uuid := kwargs["previous_revision_uuid_callable"](**kwargs):
+        revision_uuid = previous_revision_uuid
+    else:
+        revision_uuid = (
+            kwargs["dag_run"].conf["parent_submission_id"][0]
+            if isinstance(kwargs["dag_run"].conf["parent_submission_id"], list)
+            else kwargs["dag_run"].conf["parent_submission_id"]
+        )
+    response_json = make_httphook_request(
+        f"datasets/{revision_uuid}/file-system-abs-path", http_conn_id, token
+    )
+    if not (previous_revision_path := response_json.get("path")):
+        raise ValueError(f"datasets/{revision_uuid}/file-system-abs-path did not return a path")
+    return previous_revision_uuid, previous_revision_path
 
 
 def pythonop_set_dataset_state(**kwargs) -> None:
@@ -1119,7 +1115,7 @@ def get_any_dataset_uuid(**kwargs) -> str | None:
         )
 
 
-def restructure_entity_metadata(raw_metadata: JSONType) -> JSONType:
+def restructure_entity_metadata(raw_metadata: dict) -> dict:
     """
     When a dataset is initially ingested, the associated metadata is parsed and
     associated with the database representation of the dataset.  The same metadata
@@ -1137,12 +1133,10 @@ def restructure_entity_metadata(raw_metadata: JSONType) -> JSONType:
         md["contributors"] = deepcopy(raw_metadata["contributors"])
     if "antibodies" in raw_metadata:
         md["antibodies"] = deepcopy(raw_metadata["antibodies"])
-    # print('reconstructed metadata follows')
-    # pprint(md)
     return md
 
 
-def pythonop_get_dataset_state(**kwargs) -> Dict:
+def pythonop_get_dataset_state(**kwargs) -> dict:
     """
     Gets the status JSON structure for a dataset.  Works for Uploads
     and Publications as well as Datasets.
@@ -1154,32 +1148,13 @@ def pythonop_get_dataset_state(**kwargs) -> Dict:
     for arg in ["dataset_uuid_callable"]:
         assert arg in kwargs, "missing required argument {}".format(arg)
     uuid = kwargs["dataset_uuid_callable"](**kwargs)
-    method = "GET"
     auth_tok = get_auth_tok(**kwargs)
-    headers = {
-        "authorization": f"Bearer {auth_tok}",
-        "content-type": "application/json",
-        "Cache-Control": "no-cache",
-        "X-Hubmap-Application": "ingest-pipeline",
-    }
-    http_hook = HttpHook(method, http_conn_id="entity_api_connection")
-
-    endpoint = f"entities/{uuid}?exclude=direct_ancestors.files"
 
     try:
-        response = http_hook.run(
-            endpoint, headers=headers, extra_options={"check_response": False}
+        ds_rslt = make_httphook_request(
+            f"entities/{uuid}?exclude=direct_ancestors.files", "ingest_api_connection", auth_tok
         )
-        response.raise_for_status()
-        ds_rslt = response.json()
-        print("ds rslt:")
-        # pprint(ds_rslt) temporarily removed due to increasing complexity in the json
-        print(ds_rslt)
-    except HTTPError as e:
-        print(f"ERROR: {e}")
-        if e.response.status_code == codes.unauthorized:
-            raise RuntimeError("entity database authorization was rejected?")
-        print("benign error")
+    except Exception:
         return {}
 
     for key in ["status", "uuid", "entity_type"]:
@@ -1204,19 +1179,8 @@ def pythonop_get_dataset_state(**kwargs) -> Dict:
     else:
         raise RuntimeError(f"Unknown entity_type {ds_rslt['entity_type']}")
     try:
-        http_hook = HttpHook(method, http_conn_id="ingest_api_connection")
-        response = http_hook.run(
-            endpoint, headers=headers, extra_options={"check_response": False}
-        )
-        response.raise_for_status()
-        path_query_rslt = response.json()
-        print("path_query rslt:")
-        pprint(path_query_rslt)
-    except HTTPError as e:
-        print(f"ERROR: {e}")
-        if e.response.status_code == codes.unauthorized:
-            raise RuntimeError("entity database authorization was rejected?")
-        print("benign error")
+        path_query_rslt = make_httphook_request(endpoint, "ingest_api_connection", auth_tok)
+    except Exception:
         return {}
     assert "path" in path_query_rslt, f"Dataset path for {uuid} produced" " no path"
     full_path = path_query_rslt["path"]
@@ -1249,42 +1213,15 @@ def pythonop_get_dataset_state(**kwargs) -> Dict:
 
         rslt["source_type"] = source
 
-        http_hook = HttpHook("GET", http_conn_id="entity_api_connection")
-        endpoint = f"datasets/{ds_rslt['uuid']}/organs"
         try:
-            response = http_hook.run(
-                endpoint, headers=headers, extra_options={"check_response": False}
+            organs_query_rslt = make_httphook_request(
+                f"datasets/{ds_rslt['uuid']}/organs", "entity_api_connection", auth_tok, log=True
             )
-            response.raise_for_status()
-            organs_query_rslt = response.json()
-            print("organs_query_rslt:")
-            pprint(organs_query_rslt)
             rslt["organs"] = [entry["organ"] for entry in organs_query_rslt]
-        except HTTPError as e:
-            print(f"ERROR: {e}")
-            if e.response.status_code == codes.unauthorized:
-                raise RuntimeError("entity database authorization was rejected?")
-            print("benign error")
+        except Exception:
             return {}
 
     return rslt
-
-
-def _uuid_lookup(uuid, **kwargs):
-    http_conn_id = "uuid_api_connection"
-    endpoint = "hmuuid/{}".format(uuid)
-    method = "GET"
-    headers = {"authorization": "Bearer " + get_auth_tok(**kwargs)}
-    #     print('headers:')
-    #     pprint(headers)
-    extra_options = {}
-
-    http_hook = HttpHook(method, http_conn_id=http_conn_id)
-
-    response = http_hook.run(endpoint, None, headers, extra_options)
-    #     print('response: ')
-    #     pprint(response.json())
-    return response.json()
 
 
 def _generate_slices(id_to_slice: str) -> Iterable[str]:
@@ -1313,7 +1250,7 @@ def pythonop_build_dataset_lists(**kwargs) -> None:
 
     for uuid in kwargs["dag_run"].conf["uuids"]:
         soft_data = get_soft_data(uuid, **kwargs)
-        ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=lambda **kwargs: uuid, **kwargs)
+        ds_rslt = pythonop_get_dataset_state(dataset_uuid_callable=lambda **_: uuid, **kwargs)
 
         # If we got nothing back from soft_data, then let's try to determine using entity_api
         if soft_data:
@@ -1346,7 +1283,9 @@ def assert_id_known(id_to_check: str, **kwargs) -> None:
     Raises AssertionError if the ID is not known.
     """
     for slice in _generate_slices(id_to_check):
-        tissue_info = _uuid_lookup(slice, **kwargs)
+        tissue_info = make_httphook_request(
+            f"hmuuid/{slice}", "uuid_api_connection", get_auth_tok(**kwargs)
+        )
         assert tissue_info and len(tissue_info) >= 1, f"tissue_id {slice} not found on lookup"
 
 
@@ -1439,9 +1378,9 @@ def pythonop_md_consistency_tests(**kwargs) -> int:
 def get_statistics_base_path() -> Path:
     dct = airflow_conf.as_dict(display_sensitive=True)["connections"]
     if "STATISTICS_PATH" in dct:
-        return Path(dct["STATISTICS_PATH"].strip("'").strip('"'))
+        return Path(str(dct["STATISTICS_PATH"]).strip("'").strip('"'))
     elif "statistics_path" in dct:
-        return Path(dct["statistics_path"].strip("'").strip('"'))
+        return Path(str(dct["statistics_path"]).strip("'").strip('"'))
     else:
         raise KeyError("STATISTICS_PATH")
 
@@ -1456,7 +1395,9 @@ def _get_scratch_base_path() -> Path:
         scratch_path = dct["workflow_scratch"]
     else:
         raise KeyError("WORKFLOW_SCRATCH")  # preserve original code behavior
-    scratch_path = scratch_path.strip("'").strip('"')  # remove quotes that may be on the string
+    scratch_path = (
+        str(scratch_path).strip("'").strip('"')
+    )  # remove quotes that may be on the string
     return Path(scratch_path)
 
 
@@ -1483,7 +1424,7 @@ def get_cwltool_bin_path() -> Path:
     return cwltool_dir
 
 
-def get_cwltool_base_cmd(tmpdir: Path) -> List[str]:
+def get_cwltool_base_cmd(tmpdir: Path) -> list[str]:
     return [
         "env",
         "TMPDIR={}".format(tmpdir),
@@ -1505,15 +1446,15 @@ def get_cwltool_base_cmd(tmpdir: Path) -> List[str]:
     ]
 
 
-def build_provenance_function(cwl_workflows: Callable[..., List[Dict]]) -> Callable[..., List]:
-    def build_provenance(**kwargs) -> List:
+def build_provenance_function(cwl_workflows: Callable[..., list[dict]]) -> Callable[..., list]:
+    def build_provenance(**kwargs) -> list:
         # Get the previous revisions metadata
         dataset_uuid = get_previous_revision_uuid(**kwargs)
         if dataset_uuid is None:
             dataset_uuid = kwargs["dag_run"].conf.get("parent_submission_id", [None])[0]
         assert dataset_uuid is not None, "Missing previous_version_uuid"
         ds_rslt = pythonop_get_dataset_state(
-            dataset_uuid_callable=lambda **kwargs: dataset_uuid, **kwargs
+            dataset_uuid_callable=lambda **_: dataset_uuid, **kwargs
         )
 
         # Generate a new dag provenance
@@ -1523,7 +1464,7 @@ def build_provenance_function(cwl_workflows: Callable[..., List[Dict]]) -> Calla
             else []
         )
 
-        new_dag_provenance.extend(get_git_provenance_list([*cwl_workflows(**kwargs)]))
+        new_dag_provenance.extend(get_git_provenance_list(*cwl_workflows(**kwargs)))
 
         # Look through the previous revision for the pipeline invocations
         for data in ds_rslt["ingest_metadata"]["dag_provenance_list"]:
@@ -1537,16 +1478,16 @@ def build_provenance_function(cwl_workflows: Callable[..., List[Dict]]) -> Calla
 
 def make_send_status_msg_function(
     dag_file: str,
-    retcode_ops: List[str],
-    cwl_workflows: Union[List[Path], Callable[..., List[Dict]]],
+    retcode_ops: list[str],
+    cwl_workflows: list[Path] | Callable[..., list[dict]],
     uuid_src_task_id: str = "send_create_dataset",
-    dataset_uuid_fun: Optional[Callable[..., str]] = None,
-    dataset_lz_path_fun: Optional[Callable[..., str]] = None,
-    metadata_fun: Optional[Callable[..., dict]] = None,
-    include_file_metadata: Optional[bool] = True,
-    no_provenance: Optional[bool] = False,
-    workflow_description: Optional[str] = None,
-    workflow_version: Optional[str] = None,
+    dataset_uuid_fun: Callable[..., str] | None = None,
+    dataset_lz_path_fun: Callable[..., str] | None = None,
+    metadata_fun: Callable[..., dict] | None = None,
+    include_file_metadata: bool | None = True,
+    no_provenance: bool | None = False,
+    workflow_description: str | None = None,
+    workflow_version: str | None = None,
     reindex: bool = True,
 ) -> Callable[..., bool]:
     """
@@ -1632,7 +1573,7 @@ def make_send_status_msg_function(
         inner_cwl_workflows = cwl_workflows(**kwargs) if callable(cwl_workflows) else cwl_workflows
 
         ds_rslt = pythonop_get_dataset_state(
-            dataset_uuid_callable=lambda **kwargs: dataset_uuid, **kwargs
+            dataset_uuid_callable=lambda **_: dataset_uuid, **kwargs
         )
         if success:
 
@@ -1668,26 +1609,12 @@ def make_send_status_msg_function(
             if metadata_fun:
                 md["metadata"] = metadata_fun(**kwargs)
 
-            # thumbnail_file_abs_path = []
-            # if dataset_lz_path_fun:
-            #     dataset_dir_abs_path = dataset_lz_path_fun(**kwargs)
-            #     if dataset_dir_abs_path:
-            #         #########################################################################
-            #         # Added by Zhou 6/16/2021 for registering thumbnail image
-            #         # This is the only place that uses this hardcoded extras/thumbnail.jpg
-            #         thumbnail_file_abs_path = join(dataset_dir_abs_path, "extras/thumbnail.jpg")
-            #         if exists(thumbnail_file_abs_path):
-            #             thumbnail_file_abs_path = thumbnail_file_abs_path
-            #         else:
-            #             thumbnail_file_abs_path = []
-            #         #########################################################################
-
             manifest_files = find_pipeline_manifests(inner_cwl_workflows)
             if include_file_metadata and ds_dir is not None and not ds_dir == "":
                 md.update(
                     get_file_metadata_dict(
                         ds_dir,
-                        get_tmp_dir_path(kwargs["run_id"]),
+                        str(get_tmp_dir_path(kwargs["run_id"])),
                         manifest_files,
                     ),
                 )
@@ -1811,7 +1738,9 @@ def map_queue_name(raw_queue_name: str) -> str:
     conf_dict = airflow_conf.as_dict()
     if "QUEUE_NAME_TEMPLATE" in conf_dict.get("connections", {}):
         template = conf_dict["connections"]["QUEUE_NAME_TEMPLATE"]
-        template = template.strip("'").strip('"')  # remove quotes that may be on the config string
+        template = (
+            str(template).strip("'").strip('"')
+        )  # remove quotes that may be on the config string
         rslt = template.format(raw_queue_name)
         return rslt
     else:
@@ -1820,12 +1749,9 @@ def map_queue_name(raw_queue_name: str) -> str:
 
 def create_dataset_state_error_callback(
     dataset_uuid_callable: Callable[[Any], str],
-) -> Callable[[Mapping, Any], None]:
+) -> Callable[[Mapping], None]:
     # TODO: this should be deprecated in favor of status_change.callbacks.FailureCallback
     def set_dataset_state_error(context_dict: Mapping, **kwargs) -> None:
-        """
-        This routine is meant to be
-        """
         if (dag_run := kwargs.get("dag_run")) and dag_run.conf.get("dryrun"):
             return None
         msg = "An internal error occurred in the {} workflow step {}".format(
@@ -1846,7 +1772,7 @@ def create_dataset_state_error_callback(
     return set_dataset_state_error
 
 
-def _get_workflow_map() -> List[Tuple[Pattern, Pattern, str]]:
+def _get_workflow_map() -> list[Tuple[Pattern, Pattern, str]]:
     """
     Lazy compilation of workflow map
     """
@@ -1865,7 +1791,7 @@ def _get_workflow_map() -> List[Tuple[Pattern, Pattern, str]]:
     return COMPILED_WORKFLOW_MAP
 
 
-def _get_resource_map() -> List[Tuple[Pattern, Pattern, Dict[str, str]]]:
+def _get_resource_map() -> list[Tuple[Pattern, DagDct, TaskList]]:
     """
     Lazy compilation of resource map
     """
@@ -1873,10 +1799,10 @@ def _get_resource_map() -> List[Tuple[Pattern, Pattern, Dict[str, str]]]:
     if COMPILED_RESOURCE_MAP is None:
         map_path = join(dirname(__file__), RESOURCE_MAP_FILENAME)
         with open(map_path, "r") as f:
-            map = yaml.safe_load(f)
-        assert_json_matches_schema(map, RESOURCE_MAP_SCHEMA)
+            resource_map = yaml.safe_load(f)
+        assert_json_matches_schema(resource_map, RESOURCE_MAP_SCHEMA)
         cmp_map = []
-        for dct in map["resource_map"]:
+        for dct in resource_map["resource_map"]:
             dag_re = re.compile(dct["dag_re"])
             dag_dct = {key: dct[key] for key in dct if key not in ["dag_re", "tasks"]}
             tasks = []
@@ -1886,11 +1812,11 @@ def _get_resource_map() -> List[Tuple[Pattern, Pattern, Dict[str, str]]]:
                 task_dct = {key: inner_dct[key] for key in inner_dct if key not in ["task_re"]}
                 tasks.append((task_re, task_dct))
             cmp_map.append((dag_re, dag_dct, tasks))
-        COMPILED_RESOURCE_MAP = cmp_map
+        return cmp_map
     return COMPILED_RESOURCE_MAP
 
 
-def _lookup_resource_record(dag_id: str, task_id: Optional[str] = None) -> Tuple[int, Dict]:
+def _lookup_resource_record(dag_id: str, task_id: str | None = None) -> dict[str, Any]:
     """
     Look up the resource map entry for the given dag_id and task_id. The first
     match is returned.  If the task_id is None, the first record matching only
@@ -1914,7 +1840,7 @@ def _lookup_resource_record(dag_id: str, task_id: Optional[str] = None) -> Tuple
     raise ValueError("No resource map entry found for" f" dag_id <{dag_id}> task_id <{task_id}>")
 
 
-def get_queue_resource(dag_id: str, task_id: Optional[str] = None) -> str:
+def get_queue_resource(dag_id: str, task_id: str | None = None) -> str:
     """
     Look up the queue defined for this dag_id and task_id in the current
     resource map.  If the task_id is None, the lookup is done with
@@ -1947,7 +1873,7 @@ def get_preserve_scratch_resource(dag_id: str) -> bool:
     return bool(rec["preserve_scratch"])
 
 
-def get_threads_resource(dag_id: str, task_id: Optional[str] = None) -> int:
+def get_threads_resource(dag_id: str, task_id: str | None = None) -> int:
     """
     Look up the number of threads defined for this dag_id and task_id in
     the current resource map.  If the task_id is None, the lookup is done
@@ -1960,14 +1886,13 @@ def get_threads_resource(dag_id: str, task_id: Optional[str] = None) -> int:
     assert any(
         ["threads" in rec, "coreuse" in rec]
     ), 'schema should guarantee "threads" or "coreuse" is present?'
-    if rec.get("coreuse"):
-        return (
-            math.ceil(os.cpu_count() * (int(rec.get("coreuse")) / 100))
-            if int(rec.get("coreuse")) > 0
-            else math.ceil(os.cpu_count() / 4)
-        )
+    if (coreuse := rec.get("coreuse")) and (cpu_count := os.cpu_count()):
+        if type(coreuse) is int and coreuse > 0:
+            return math.ceil(cpu_count * coreuse) % 100
+        else:
+            return math.ceil(cpu_count / 4)
     else:
-        return int(rec.get("threads"))
+        return int(rec["threads"])
 
 
 def downstream_workflow_iter(collectiontype: str, assay_type: StrOrListStr) -> Iterable[str]:
@@ -1989,17 +1914,17 @@ def downstream_workflow_iter(collectiontype: str, assay_type: StrOrListStr) -> I
 
 def encrypt_tok(cleartext_tok: str) -> bytes:
     key = airflow_conf.as_dict(display_sensitive=True)["core"]["fernet_key"]
-    fernet = Fernet(key.encode())
+    fernet = Fernet(str(key).encode())
     return fernet.encrypt(cleartext_tok.encode())
 
 
 def decrypt_tok(crypt_tok: bytes) -> str:
     key = airflow_conf.as_dict(display_sensitive=True)["core"]["fernet_key"]
-    fernet = Fernet(key.encode())
+    fernet = Fernet(str(key).encode())
     return fernet.decrypt(crypt_tok).decode()
 
 
-def join_quote_command_str(pieces: List[Any]):
+def join_quote_command_str(pieces: list[Any]):
     command_str = " ".join(shlex.quote(str(piece)) for piece in pieces)
     print("final command_str:", command_str)
     return command_str
@@ -2028,30 +1953,14 @@ def find_matching_endpoint(host_url: str) -> str:
     return candidates[0]
 
 
-def get_soft_data(dataset_uuid, **kwargs) -> Optional[dict]:
+def get_soft_data(dataset_uuid, **kwargs) -> dict:
     """
     Gets the soft data type for a specific uuid.
     """
-    endpoint = f"/assaytype/{dataset_uuid}"
-    http_hook = HttpHook("GET", http_conn_id="ingest_api_connection")
-    headers = {
-        "authorization": "Bearer " + get_auth_tok(**kwargs),
-        "content-type": "application/json",
-        "X-Hubmap-Application": "ingest-pipeline",
-    }
-    try:
-        response = http_hook.run(endpoint, headers=headers)
-        response.raise_for_status()
-        response = response.json()
-        print(f"rule_set response for {dataset_uuid} follows")
-        pprint(response)
-    except HTTPError as e:
-        print(f"ERROR: {e} fetching full path for {dataset_uuid}")
-        if e.response.status_code == codes.unauthorized:
-            raise RuntimeError("ingest_api_connection authorization was rejected?")
-        print("benign error")
-        return None
-    return response
+    print("Fetching rule_set response...")
+    return make_httphook_request(
+        f"/assaytype/{dataset_uuid}", "ingest_api_connection", get_auth_tok(**kwargs), log=True
+    )
 
 
 def get_soft_data_assaytype(dataset_uuid, **kwargs) -> str:
@@ -2070,52 +1979,54 @@ def gather_calculated_metadata(**kwargs):
 
 
 def post_to_slack_notify(token: str, message: str, channel: str):
-    http_hook = HttpHook("POST", http_conn_id="ingest_api_connection")
-    payload = json.dumps({"message": message, "channel": channel})
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    response = http_hook.run("/notify", payload, headers)
-    response.raise_for_status()
+    payload = {"message": message, "channel": channel}
+    return make_httphook_request(
+        "/notify", "ingest_api_connection", token, method="POST", payload=payload, log=True
+    )
 
 
-def env_appropriate_slack_channel(prod_channel: str) -> str:
-    default = "C0A8ES4M9RU"  # test-notifications
+def get_env() -> str:
+    """
+    Return lowercase env str ("prod", "dev")
+    or default to empty string.
+    """
     entity_host = HttpHook.get_connection("entity_api_connection").host or ""
     try:
         env = find_matching_endpoint(entity_host) or ""
     except AssertionError:
-        env = "dev"
-    if env.lower() == "prod":
+        env = ""
+    return env.lower()
+
+
+def env_appropriate_slack_channel(prod_channel: str) -> str:
+    if get_env() == "prod":
         return prod_channel
-    return default
+    return "C0A8ES4M9RU"  # test-notifications
 
 
-# This is simplified from pythonop_get_dataset_state in utils
-def get_submission_context(token: str, uuid: str, headers: dict | None = None) -> dict[str, Any]:
+def get_submission_context(token: str, uuid: str) -> dict[str, Any]:
     """
     uuid can also be a HuBMAP/SenNet ID.
     """
-    if not headers:
-        headers = {
-            "authorization": f"Bearer {token}",
-            "content-type": "application/json",
-            f"X-Hubmap-Application": "ingest-pipeline",
-        }
-    http_hook = HttpHook("GET", http_conn_id="entity_api_connection")
-
-    endpoint = f"entities/{uuid}?exclude=direct_ancestors.files"
-
     try:
-        response = http_hook.run(
-            endpoint, headers=headers, extra_options={"check_response": False}
+        return make_httphook_request(
+            f"entities/{uuid}?exclude=direct_ancestors.files", "entity_api_connection", token
         )
-        response.raise_for_status()
-        return response.json()
-    except HTTPError as e:
-        print(f"ERROR: {e}")
-        if e.response.status_code == codes.unauthorized:
-            raise RuntimeError("entity database authorization was rejected?")
-        print("benign error")
-        return {}
+    except JSONDecodeError as e:
+        # Edge case: if the metadata response is too large, ingest_api will send a
+        # link to the full content in the text body of the response; try to follow
+        # that (do not log it, it's too large!!)
+        if e.response:
+            if "message:https" in e.response.text:
+                try:
+                    url = e.response.text.split("message:http")[-1:][0]
+                    print(f"Trying redirect URL ('{url}') from message body...")
+                    response = requests.get(url)
+                    response.raise_for_status()
+                    return response.json()
+                except Exception:
+                    print("Redirect request failed.")
+        raise
 
 
 def main():
@@ -2192,12 +2103,12 @@ def get_config_value_ext_recipients() -> list[str]:
 
 
 def send_email(
-    contacts: list[str],
+    contacts: list[str] | str,
     subject: str,
     email_body: str,
-    attachment_path: Optional[str] = None,
-    cc: Optional[list[str]] = None,
-    bcc: Optional[list[str]] = None,
+    attachment_path: str | None = None,
+    cc: list[str] = [],
+    bcc: list[str] = [],
     prod_only: bool = True,
 ) -> bool:
     assert contacts and email_body
@@ -2215,13 +2126,9 @@ def send_email(
     ).strip()
     contacts = list(set(contacts))
     if prod_only:
-        host_str = HttpHook.get_connection("entity_api_connection").host
-        env = find_matching_endpoint(host_str) if host_str else ""
-        if env.lower() != "prod":
+        if get_env() != "prod":
             logging.info("Non-prod environment, fetching overrides from config.")
             contacts = []
-            cc = None
-            bcc = None
             if config_ext_recipients := get_config_value_int_recipients():
                 contacts = config_ext_recipients
             if config_int_recipients := get_config_value_int_recipients():

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -521,10 +521,7 @@ def get_git_commits(file_list: StrOrListStr) -> StrOrListStr:
     Given a list of file paths, return a list of the current short commit hashes of those files
     """
     rslt = []
-    if isinstance(file_list, str):  # sadly, a str is an Iterable[str]
-        cleaned_file_list = [file_list]
-    else:
-        cleaned_file_list = file_list
+    cleaned_file_list = file_list if isinstance(file_list, list) else [file_list]
     for fname in cleaned_file_list:
         log_command = [piece.format(fname=fname) for piece in GIT_LOG_COMMAND]
         try:
@@ -560,10 +557,7 @@ def get_git_origins(file_list: StrOrListStr) -> StrOrListStr:
     Given a list of file paths, return a list of the git origins of those files
     """
     rslt = []
-    if isinstance(file_list, str):  # sadly, a str is an Iterable[str]
-        cleaned_file_list = [file_list]
-    else:
-        cleaned_file_list = file_list
+    cleaned_file_list = file_list if isinstance(file_list, list) else [file_list]
     for fname in cleaned_file_list:
         command = [piece.format(fname=fname) for piece in GIT_ORIGIN_COMMAND]
         try:
@@ -1880,7 +1874,7 @@ def get_threads_resource(dag_id: str, task_id: str | None = None) -> int:
     ), 'schema should guarantee "threads" or "coreuse" is present?'
     if (coreuse := rec.get("coreuse")) and (cpu_count := os.cpu_count()):
         if type(coreuse) is int and coreuse > 0:
-            return math.ceil(cpu_count * coreuse) % 100
+            return math.ceil(cpu_count * (coreuse // 100))
         else:
             return math.ceil(cpu_count / 4)
     else:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -304,7 +304,7 @@ def get_cwl_cmd_from_workflows(
     if not outdir_present:
         command.extend(["--outdir", str(tmp_dir / "cwl_out")])
 
-    command.append(workflow["workflow_path"])
+    command.append(Path(workflow["workflow_path"]))
 
     # Extend the command with the input parameters
     for param in workflow["input_parameters"]:
@@ -1410,7 +1410,7 @@ def get_cwltool_bin_path() -> Path:
     return cwltool_dir
 
 
-def get_cwltool_base_cmd(tmpdir: Path) -> list[str]:
+def get_cwltool_base_cmd(tmpdir: Path) -> list[str | Path]:
     return [
         "env",
         "TMPDIR={}".format(tmpdir),

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -998,6 +998,8 @@ def pythonop_send_create_dataset(**kwargs) -> str:
     response_json = make_httphook_request(
         "datasets", http_conn_id, token, method="POST", payload=data
     )
+    print("response from dataset creation...")
+    print(response_json)
 
     for elt in ["uuid", "group_uuid"]:
         if elt not in response_json:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -979,7 +979,9 @@ def pythonop_send_create_dataset(**kwargs) -> str:
     # get previous_revision_path and previous_revision_uuid (if applicable)
     previous_revision_path = None
     if "previous_revision_uuid_callable" in kwargs:
-        if previous_revision_uuid := kwargs["previous_revision_uuid_callable"](**kwargs):
+        previous_revision_uuid = kwargs["previous_revision_uuid_callable"](**kwargs)
+        if previous_revision_uuid is not None:
+            data["previous_revision_uuid"] = previous_revision_uuid
             revision_uuid = previous_revision_uuid
         else:
             revision_uuid = (
@@ -994,7 +996,6 @@ def pythonop_send_create_dataset(**kwargs) -> str:
             raise ValueError(
                 f"datasets/{revision_uuid}/file-system-abs-path did not return a path"
             )
-        data["previous_revision_uuid"] = previous_revision_uuid
 
     # create dataset
     print("data for dataset creation:")
@@ -2018,10 +2019,9 @@ def get_submission_context(token: str, uuid: str, headers: dict | None = None) -
             headers=headers,
             return_text_response=True,
         )
-        if type(entity_api_response) is str and entity_api_response.startswith("http"):
-            url = entity_api_response.text
-            print(f"Trying redirect URL ('{url}') from message body...")
-            redir_response = requests.get(url)
+        if type(entity_api_response) is str and "hm-api-responses" in entity_api_response:
+            print(f"Trying redirect URL ('{entity_api_response}') from message body...")
+            redir_response = requests.get(entity_api_response)
             redir_response.raise_for_status()
             return redir_response.json()
         raise

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -30,8 +30,8 @@ import cwltool  # used to find its path
 import requests
 import yaml
 from cryptography.fernet import Fernet
-from requests import JSONDecodeError, codes
-from requests.exceptions import HTTPError
+from requests import codes
+from requests.exceptions import HTTPError, JSONDecodeError
 from schema_utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,
 )
@@ -885,32 +885,41 @@ def make_httphook_request(
             "content-type": "application/json",
             "X-Hubmap-Application": "ingest-pipeline",
         }
-
+    http_hook = HttpHook(method, http_conn_id=http_conn_id)
+    run_args = {"endpoint": endpoint, "headers": headers}
+    if method.lower() == "post":
+        run_args["payload"] = json.dumps(payload)
     try:
-        if method.lower() == "post":
-            response = HttpHook(method, http_conn_id=http_conn_id).run(
-                endpoint=endpoint, headers=headers, payload=json.dumps(payload)
-            )
-        else:
-            response = HttpHook(method, http_conn_id=http_conn_id).run(
-                endpoint=endpoint, headers=headers
-            )
+        response = http_hook.run(**run_args)
         response.raise_for_status()
-        response_json = response.json()
-        if log:
-            print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
-            print(response_json)
-        return response_json
     except HTTPError as e:
         print(f"ERROR: {e}")
         if e.response.status_code == codes.unauthorized:
             raise RuntimeError(f"authorization for {endpoint} was rejected?")
         raise RuntimeError(f"misc error {e} on {endpoint}")
+    try:
+        response_json = response.json()
+        if log:
+            print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
+            print(response_json)
+        return response_json
     except JSONDecodeError as e:
-        if e.response:
+        if response.text:
             print(
-                f"Received non-JSON response. Text: {e.response.text}; content: {e.response.content}"
+                f"Received non-JSON response. Text: {response.text}; content: {response.content}"
             )
+            # Edge case: if the metadata response is too large, ingest_api will send a
+            # link to the full content in the text body of the response; try to follow
+            # that (do not log it, it's too large!!)
+            if "message:https" in response.text:
+                try:
+                    url = response.text.split("message:")[-1:][0]
+                    print(f"Trying redirect URL ('{url}') from message body...")
+                    redir_response = requests.get(url)
+                    redir_response.raise_for_status()
+                    return redir_response.json()
+                except Exception:
+                    print("Redirect request failed.")
         raise
 
 
@@ -1151,9 +1160,7 @@ def pythonop_get_dataset_state(**kwargs) -> dict:
     auth_tok = get_auth_tok(**kwargs)
 
     try:
-        ds_rslt = make_httphook_request(
-            f"entities/{uuid}?exclude=direct_ancestors.files", "ingest_api_connection", auth_tok
-        )
+        ds_rslt = get_submission_context(auth_tok, uuid)
     except Exception:
         return {}
 
@@ -2006,30 +2013,15 @@ def env_appropriate_slack_channel(prod_channel: str) -> str:
 
 def get_submission_context(token: str, uuid: str, headers: dict | None = None) -> dict[str, Any]:
     """
+    Get info about an entity as returned by ingest_api.
     uuid can also be a HuBMAP/SenNet ID.
     """
-    try:
-        return make_httphook_request(
-            f"entities/{uuid}?exclude=direct_ancestors.files",
-            "entity_api_connection",
-            token,
-            headers=headers,
-        )
-    except JSONDecodeError as e:
-        # Edge case: if the metadata response is too large, ingest_api will send a
-        # link to the full content in the text body of the response; try to follow
-        # that (do not log it, it's too large!!)
-        if e.response:
-            if "message:https" in e.response.text:
-                try:
-                    url = e.response.text.split("message:http")[-1:][0]
-                    print(f"Trying redirect URL ('{url}') from message body...")
-                    response = requests.get(url)
-                    response.raise_for_status()
-                    return response.json()
-                except Exception:
-                    print("Redirect request failed.")
-        raise
+    return make_httphook_request(
+        f"entities/{uuid}?exclude=direct_ancestors.files",
+        "ingest_api_connection",
+        token,
+        headers=headers,
+    )
 
 
 def main():

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -892,7 +892,7 @@ def make_httphook_request(
     try:
         response_json = response.json()
         print(f"Response from '{method}' on {endpoint} ({http_conn_id}):")
-        if content_len := response.get("Content-Length"):
+        if content_len := response.headers.get("Content-Length"):
             if int(content_len) > 500000:  # length chosen arbitrarily, feel free to change
                 print(f"Response too long, not logging.")
         else:

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -899,6 +899,7 @@ def make_httphook_request(
             print(response_json)
         return response_json
     except JSONDecodeError as e:
+        # Will raise unless response has `text` property and `return_text_response=True` (non-default)
         if response.text:
             print(
                 f"Received non-JSON response. Text: {response.text}; content: {response.content}"
@@ -1947,7 +1948,7 @@ def get_soft_data(dataset_uuid, **kwargs) -> dict:
     """
     print("Fetching rule_set response...")
     return make_httphook_request(
-        f"/assaytype/{dataset_uuid}", "ingest_api_connection", get_auth_tok(**kwargs)
+        f"assaytype/{dataset_uuid}", "ingest_api_connection", get_auth_tok(**kwargs)
     )
 
 
@@ -1969,7 +1970,7 @@ def gather_calculated_metadata(**kwargs):
 def post_to_slack_notify(token: str, message: str, channel: str):
     payload = {"message": message, "channel": channel}
     return make_httphook_request(
-        "/notify", "ingest_api_connection", token, method="POST", payload=payload
+        "notify", "ingest_api_connection", token, method="POST", payload=payload
     )
 
 
@@ -2018,57 +2019,6 @@ def get_submission_context(
         redir_response.raise_for_status()
         return redir_response.json()
     raise Exception(f"GET request to entity-api for {uuid} failed!")
-
-
-def main():
-    """
-    This provides some unit tests.  To run it, you will need to define the
-    'search_api_connection' connection ID and the Fernet key.  The easiest way
-    to do that is with something like:
-
-      export AIRFLOW_CONN_SEARCH_API_CONNECTION='https://search.api.hubmapconsortium.org/v3/
-      fernet_key=`python -c 'from cryptography.fernet import Fernet ; print(Fernet.generate_key().decode())'`
-      export AIRFLOW__CORE__FERNET_KEY=${fernet_key}
-    """
-    print(__file__)
-    print(get_git_commits([__file__]))
-    print(get_git_provenance_dict(__file__))
-    dirnm = dirname(__file__)
-    if dirnm == "":
-        dirnm = "."
-    for elt in get_file_metadata(dirnm, DummyFileMatcher()):
-        print(elt)
-    pprint(get_git_provenance_list(__file__))
-    md = {
-        "metadata": {"my_string": "hello world"},
-        "files": get_file_metadata(dirnm, DummyFileMatcher()),
-        "dag_provenance_list": get_git_provenance_list(__file__),
-    }
-    try:
-        assert_json_matches_schema(md, "dataset_metadata_schema.yml")
-        print("ASSERT passed")
-    except AssertionError as e:
-        print(f"ASSERT failed {e}")
-
-    assay_pairs = [
-        ("devtest", "devtest"),
-        ("codex", "CODEX"),
-        ("codex", "SOMEOTHER"),
-        ("someother", "CODEX"),
-        ("someother", "salmon_sn_rnaseq_10x"),
-        ("someother", "salmon_rnaseq_10x_sn"),
-    ]
-    for collectiontype, assay_type in assay_pairs:
-        print("collectiontype {}, assay_type {}:".format(collectiontype, assay_type))
-        for elt in downstream_workflow_iter(collectiontype, assay_type):
-            print("  -> {}".format(elt))
-
-    print(f"cwltool bin path: {get_cwltool_bin_path()}")
-
-    s = "hello world"
-    crypt_s = encrypt_tok(s)
-    s2 = decrypt_tok(crypt_s)
-    print("crypto test: {} -> {} -> {}".format(s, crypt_s, s2))
 
 
 def get_config_value_int_recipients() -> list[str]:
@@ -2145,6 +2095,57 @@ def send_email(
         bcc=bcc,
     )
     return True
+
+
+def main():
+    """
+    This provides some unit tests.  To run it, you will need to define the
+    'search_api_connection' connection ID and the Fernet key.  The easiest way
+    to do that is with something like:
+
+      export AIRFLOW_CONN_SEARCH_API_CONNECTION='https://search.api.hubmapconsortium.org/v3/
+      fernet_key=`python -c 'from cryptography.fernet import Fernet ; print(Fernet.generate_key().decode())'`
+      export AIRFLOW__CORE__FERNET_KEY=${fernet_key}
+    """
+    print(__file__)
+    print(get_git_commits([__file__]))
+    print(get_git_provenance_dict(__file__))
+    dirnm = dirname(__file__)
+    if dirnm == "":
+        dirnm = "."
+    for elt in get_file_metadata(dirnm, DummyFileMatcher()):
+        print(elt)
+    pprint(get_git_provenance_list(__file__))
+    md = {
+        "metadata": {"my_string": "hello world"},
+        "files": get_file_metadata(dirnm, DummyFileMatcher()),
+        "dag_provenance_list": get_git_provenance_list(__file__),
+    }
+    try:
+        assert_json_matches_schema(md, "dataset_metadata_schema.yml")
+        print("ASSERT passed")
+    except AssertionError as e:
+        print(f"ASSERT failed {e}")
+
+    assay_pairs = [
+        ("devtest", "devtest"),
+        ("codex", "CODEX"),
+        ("codex", "SOMEOTHER"),
+        ("someother", "CODEX"),
+        ("someother", "salmon_sn_rnaseq_10x"),
+        ("someother", "salmon_rnaseq_10x_sn"),
+    ]
+    for collectiontype, assay_type in assay_pairs:
+        print("collectiontype {}, assay_type {}:".format(collectiontype, assay_type))
+        for elt in downstream_workflow_iter(collectiontype, assay_type):
+            print("  -> {}".format(elt))
+
+    print(f"cwltool bin path: {get_cwltool_bin_path()}")
+
+    s = "hello world"
+    crypt_s = encrypt_tok(s)
+    s2 = decrypt_tok(crypt_s)
+    print("crypto test: {} -> {} -> {}".format(s, crypt_s, s2))
 
 
 if __name__ == "__main__":

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -1996,34 +1996,28 @@ def get_submission_context(
     token: str, uuid: str, headers: dict | None = None, log: bool = True
 ) -> dict[str, Any]:
     """
-    Get info about an entity as returned by ingest_api.
+    Get info about an entity as returned by entity-api.
     uuid can also be a HuBMAP/SenNet ID.
     """
-    try:
-        return make_httphook_request(
-            f"entities/{uuid}?exclude=direct_ancestors.files",
-            "ingest_api_connection",
-            token,
-            headers=headers,
-            log=log,
-        )
-    except JSONDecodeError:
-        # Edge case: if the metadata response is too large, ingest API will send a
-        # message including the link to the full metadata, but as part of longer message;
-        # call entity API directly to get just the link, follow it, and try to return response
-        entity_api_response = make_httphook_request(
-            f"entities/{uuid}",
-            "entity_api_connection",
-            token,
-            headers=headers,
-            return_text_response=True,
-        )
-        if type(entity_api_response) is str and "hm-api-responses" in entity_api_response:
-            print(f"Trying redirect URL ('{entity_api_response}') from message body...")
-            redir_response = requests.get(entity_api_response)
-            redir_response.raise_for_status()
-            return redir_response.json()
-        raise
+    context = make_httphook_request(
+        f"entities/{uuid}?exclude=direct_ancestors.files",
+        "entity_api_connection",
+        token,
+        headers=headers,
+        log=log,
+        return_text_response=True,
+    )
+    if type(context) is dict:
+        return context
+    # Edge case: if the metadata response is too large, entity-api will send a
+    # message with a link to the full metadata; try to follow that link and
+    # return response; this WILL add a good amount of processing time
+    elif type(context) is str and "hm-api-responses" in context:
+        print(f"Trying redirect URL ('{context}') from message body...")
+        redir_response = requests.get(context)
+        redir_response.raise_for_status()
+        return redir_response.json()
+    raise Exception(f"GET request to entity-api for {uuid} failed!")
 
 
 def main():

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -899,7 +899,6 @@ def make_httphook_request(
             print(response_json)
         return response_json
     except JSONDecodeError as e:
-        # Will raise unless response has `text` property
         if response.text:
             print(
                 f"Received non-JSON response. Text: {response.text}; content: {response.content}"


### PR DESCRIPTION
tl;dr: Got a non-JSON response from Ingest API in a case where the metadata was too large. The goal of this work was to:
- Fix the issue
- Catch JSONDecodeErrors

I did that and some refactoring. (Type-checker users, rejoice.)

----

Ultimately, the issue was that `pythonop_send_create_dataset` was calling ingest-api to retrieve the parent dataset info. Although `exclude=direct_ancestors.files` was included in that call, that param was not passed on to ingest-api's call to entity-api. This caused the response to be too large for ingest-api to return, so it returned a message in the `text` attribute. I solved this by calling entity-api directly with the appropriate param.

### Fixed case where `pythonop_send_create_dataset` fails due to large response.
- Refactoring function during troubleshooting to remove overlong try/except block.
- Abstracted request code into a reusable function (`make_httphook_request`).
     - Added error logging for non-JSON responses.
     - Added logging truncation to `make_httphook_request` to prevent laggy Airflow logs.
- Integration of helper function `get_submission_context` should ensure this issue does not happen again.

### Surface-level refactor of utils.py.
- Replaced repeated request code in other functions with `make_httphook_request` / `get_submission_context`.
- Added `get_env` function to consolidate environment checking.
- Modernized typing (removed List, Dict, Union, Optional).
- Finally cleaned up the typing issues identified by my type checker (e.g. issues with functions using generic type `StrOrListStr`, casting data to the correct type before performing other operations, handling null cases, etc.).

### Other
- Added Publication QA to "good statuses" for email messaging.