### PR TITLE
Add pipeline name to messages where available

### DIFF
--- a/src/ingest-pipeline/airflow/dags/status_change/email_templates/error.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/email_templates/error.py
@@ -6,10 +6,14 @@ from .base import EmailTemplate
 class ErrorStatusEmail(EmailTemplate):
 
     def format(self) -> tuple[str, str]:
+        pipeline = f"[{self.data.processing_pipeline}] " if self.data.processing_pipeline else ""
+        # Derived dataset created
         if self.data.derived:
-            subj = f"Internal error for derived dataset {self.data.entity_id}"
+            subj = f"{pipeline}Internal error for derived dataset {self.data.entity_id}"
+        # Pipeline failed before dataset creation
         elif self.data.processing_pipeline:
-            subj = f"Pipeline {self.data.processing_pipeline} failed for {self.data.entity_id}"
+            subj = f"{pipeline}Pipeline failed for {self.data.entity_id}"
+        # Primary dataset
         else:
             subj = f"Internal error for {self.data.entity_type.lower()} {self.data.entity_id}"
         msg = self.format_msg()

--- a/src/ingest-pipeline/airflow/dags/status_change/email_templates/good.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/email_templates/good.py
@@ -6,10 +6,11 @@ from .base import EmailTemplate
 class GenericGoodStatusEmail(EmailTemplate):
 
     def format(self) -> tuple[str, str]:
+        pipeline = f"[{self.data.processing_pipeline}] " if self.data.processing_pipeline else ""
         if self.data.derived:
-            subj = f"Derived dataset {self.data.entity_id} has successfully reached status {self.data.status.titlecase}!"
+            subj = f"{pipeline}Derived dataset {self.data.entity_id} has successfully reached status {self.data.status.titlecase}!"
         else:
-            subj = f"{self.data.entity_type} {self.data.entity_id} has successfully reached status {self.data.status.titlecase}!"
+            subj = f"{pipeline}{self.data.entity_type} {self.data.entity_id} has successfully reached status {self.data.status.titlecase}!"
         msg = [
             f"View ingest record: {get_entity_ingest_url(self.data.entity_data)}",
             *self.footer,

--- a/src/ingest-pipeline/airflow/dags/status_change/slack/error.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack/error.py
@@ -27,14 +27,15 @@ class SlackDatasetErrorProcessing(SlackMessage):
     name = "dataset_error_processing"
 
     def format(self):
+        pipeline = f"[{self.processing_pipeline}] " if self.processing_pipeline else ""
         derived = get_is_derived(self.entity_data)
         if derived:
-            message = [f"Derived dataset {self.entity_id} | {self.uuid} is in Error state."]
+            message = [
+                f"{pipeline}Derived dataset {self.entity_id} | {self.uuid} is in Error state."
+            ]
         else:
             message = [
-                f"Pipeline processing "
-                + (f"({self.processing_pipeline}) " if self.processing_pipeline else "")
-                + f"failed for {self.entity_id} | {self.uuid}. No derived dataset created."
+                f"{pipeline}Pipeline processing failed for {self.entity_id} | {self.uuid}. No derived dataset created."
             ]
         message.extend(self.entity_links)
         if derived and self.primary_dataset_info:

--- a/src/ingest-pipeline/airflow/dags/status_change/slack/new.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack/new.py
@@ -14,7 +14,8 @@ class SlackDatasetNewDerived(SlackMessage):
     name = "dataset_new_derived"
 
     def format(self):
-        message = [f"Derived dataset {self.entity_id} | {self.uuid} has been created."]
+        pipeline = f"[{self.processing_pipeline}] " if self.processing_pipeline else ""
+        message = [f"{pipeline}Derived dataset {self.entity_id} | {self.uuid} has been created."]
         message.extend(self.entity_links)
         if self.primary_dataset_info:
             message.append(f"Primary dataset: {self.create_primary_link()}.")

--- a/src/ingest-pipeline/airflow/dags/status_change/slack/qa.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/slack/qa.py
@@ -19,7 +19,8 @@ class SlackDatasetQADerived(SlackMessage):
         return get_is_derived(entity_data)
 
     def format(self):
-        message = [f"Derived dataset {self.entity_id} | {self.uuid} has reached QA!"]
+        pipeline = f"[{self.processing_pipeline}] " if self.processing_pipeline else ""
+        message = [f"{pipeline}Derived dataset {self.entity_id} | {self.uuid} has reached QA!"]
         if self.primary_dataset_info:
             message.append(f"Primary dataset: {self.create_primary_link()}.")
         message.extend(self.entity_links)

--- a/tests/test_status_changer.py
+++ b/tests/test_status_changer.py
@@ -6,7 +6,6 @@ from functools import cached_property
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import requests
-from fixtures import dataset_context_mock_value, endpoints, good_upload_context
 from status_change.callbacks.failure_callback import FailureCallback
 from status_change.data_ingest_board_manager import DataIngestBoardManager
 from status_change.email_manager import EmailManager
@@ -1124,19 +1123,35 @@ class TestEmailManager(MockParent):
                     cc=[INT_RECIPIENTS],
                 )
 
-    def test_get_content_error(self):
+    def test_get_content_error_upload(self):
         manager = self.email_manager(
             Statuses.UPLOAD_ERROR,
             context=good_upload_context | {"error_message": "An error has occurred"},
         )
-        expected_subj = "Internal error for upload test_hm_id"
         expected_msg = "HuBMAP ID: test_hm_id<br>UUID: test_uuid<br>Entity type: Upload<br>Status: Error<br>Group: test group<br>Primary contact: test@user.com<br>Ingest page: https://ingest.hubmapconsortium.org/upload/test_uuid<br>Run ID: test_run_id<br>Log file: test_path/test_run_id<br>"
-        # print(f"Expected subject: {expected_subj}")
-        # print(f"Actual subj: {manager.subj}")
-        # print(f"Expected msg: {expected_msg}")
-        # print(f"Actual msg: {manager.msg}")
-        assert manager.subj == expected_subj
+        assert manager.subj == "Internal error for upload test_hm_id"
         assert manager.msg == expected_msg
+
+    def test_get_subj_error_dataset(self):
+        manager = self.email_manager(
+            Statuses.DATASET_ERROR,
+            context=dataset_context_mock_value | {"error_message": "An error has occurred"},
+            messages={"processing_pipeline": "test_pipeline"},
+        )
+        assert manager.subj == f"[test_pipeline] Pipeline failed for test_hm_dataset_id"
+
+    def test_get_subj_error_derived_dataset(self):
+        manager = self.email_manager(
+            Statuses.DATASET_ERROR,
+            context=dataset_context_mock_value
+            | derived_dataset_context_mock_value
+            | {"error_message": "An error has occurred"},
+            messages={"processing_pipeline": "test_pipeline"},
+        )
+        assert (
+            manager.subj
+            == f"[test_pipeline] Internal error for derived dataset test_hm_dataset_id"
+        )
 
     def test_get_content_invalid(self):
         manager = self.email_manager(


### PR DESCRIPTION
Prefix "[pipeline-name]" to Slack messages and email subjects when available.