### PR TITLE
Error status resetting

### DIFF
--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -367,9 +367,12 @@ class StatusChanger(EntityUpdater):
         if primary_status != "error":
             return
         try:
-            logging.info(f"Updating primary dataset status from {primary_status} to QA.")
+            logging.info(f"Updating primary dataset status from Error to QA.")
             response = put_request_to_entity_api(
-                primary_uuid, self.token, {"status": "QA"}, {"reindex-priority": self.reindex}
+                primary_uuid,
+                self.token,
+                {"status": "QA", "pipeline_message": ""},
+                {"reindex-priority": self.reindex},
             )
             logging.info(f"Response: {response}")
         except Exception as e:

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -258,7 +258,7 @@ class StatusChanger(EntityUpdater):
             - If same_status: continue to call_message_managers.
         - Validates fields with parent method and adds status to fields_to_change.
         - Runs parent set_entity_api_data() process.
-        - Special case: new or QA derived dataset should make sure parent
+        - Special case: new or QA derived dataset should make sure primary
             dataset status is QA
         - Instantiates messaging classes, sends updates based on message class's
             is_valid_for_status value.

--- a/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
+++ b/src/ingest-pipeline/airflow/dags/status_change/status_manager.py
@@ -19,6 +19,8 @@ from .status_utils import (
     MessageManager,
     Statuses,
     enums_to_lowercase,
+    get_is_derived,
+    get_primary_dataset,
     get_status_enum,
     get_submission_context,
     put_request_to_entity_api,
@@ -255,7 +257,9 @@ class StatusChanger(EntityUpdater):
             - If no status: return (nothing left to do).
             - If same_status: continue to call_message_managers.
         - Validates fields with parent method and adds status to fields_to_change.
-        - Runs parent _set_entity_api_data() process.
+        - Runs parent set_entity_api_data() process.
+        - Special case: new or QA derived dataset should make sure parent
+            dataset status is QA
         - Instantiates messaging classes, sends updates based on message class's
             is_valid_for_status value.
         """
@@ -275,6 +279,11 @@ class StatusChanger(EntityUpdater):
             logging.info("Updating status...")
             self.validate_fields_to_change()
             self.set_entity_api_data()
+        if get_is_derived(self.entity_data) and self.status in [
+            Statuses.DATASET_QA,
+            Statuses.DATASET_NEW,
+        ]:
+            self.update_primary_dataset()
         call_message_managers(
             self.status, self.uuid, self.token, self.messages, self.message_classes
         )
@@ -341,6 +350,32 @@ class StatusChanger(EntityUpdater):
         # Slightly fragile, needs to keep pace with EntityUpdater.update()
         super().validate_fields_to_change()
         super().set_entity_api_data()
+
+    def update_primary_dataset(self):
+        """
+        If a derived dataset reaches status "New" or "QA," reset
+        primary to "QA" if it was previously set to "Error" by failed
+        derived dataset creation.
+        """
+        primary_uuid = get_primary_dataset(self.entity_data, self.token)
+        if not primary_uuid:
+            raise EntityUpdateException(
+                f"Can't find primary dataset for derived dataset {self.uuid}, not updating."
+            )
+        primary_metadata = get_submission_context(self.token, primary_uuid)
+        primary_status = primary_metadata.get("status", "").lower()
+        if primary_status != "error":
+            return
+        try:
+            logging.info(f"Updating primary dataset status from {primary_status} to QA.")
+            response = put_request_to_entity_api(
+                primary_uuid, self.token, {"status": "QA"}, {"reindex-priority": self.reindex}
+            )
+            logging.info(f"Response: {response}")
+        except Exception as e:
+            raise EntityUpdateException(
+                f"Error changing status for primary dataset {primary_uuid}: {e}"
+            )
 
 
 message_class_map = {

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -28,13 +28,13 @@ from typing import (
 
 import cwltool  # used to find its path
 import yaml
+from crate_manager import CrateManager, DummyCrateManager
 from cryptography.fernet import Fernet
 from requests import codes
 from requests.exceptions import HTTPError, JSONDecodeError
 from schema_utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,
 )
-from crate_manager import CrateManager, DummyCrateManager
 
 from airflow import DAG
 from airflow.configuration import conf as airflow_conf
@@ -272,14 +272,14 @@ def find_pipeline_manifests(cwl_files: list[Path] | list[dict] | str) -> list[Pa
 
 
 def get_cwl_cmd_from_workflows(
-        workflows: list[dict],
-        workflow_index: int,
-        input_param_vals: list,
-        tmp_dir: Path,
-        ti,
-        cwl_param_vals: list[dict] | None = None,
-        crate_manager: CrateManager | None = None,
-        session = None,
+    workflows: list[dict],
+    workflow_index: int,
+    input_param_vals: list,
+    tmp_dir: Path,
+    ti,
+    cwl_param_vals: list[dict] | None = None,
+    crate_manager: CrateManager | None = None,
+    session=None,
 ) -> list:
     """
     :param workflows: Iterable of workflow dictionaries
@@ -315,8 +315,7 @@ def get_cwl_cmd_from_workflows(
 
     # Add the provenance argument for this workflow, if any
     if crate_manager:
-        assert session is not None, ("A valid session is required"
-                                     " when using rocrates")
+        assert session is not None, "A valid session is required" " when using rocrates"
         command += crate_manager.get_args(tmp_dir, ti, session)
 
     command.append(Path(workflow["workflow_path"]))
@@ -1450,6 +1449,7 @@ def build_provenance_function(
         contains one of these keywords are kept. Pass None to keep the entire
         prior-revision provenance list, in order, ahead of the new one.
     """
+
     def build_provenance(**kwargs) -> list:
         # Get the previous revisions metadata
         dataset_uuid = get_previous_revision_uuid(**kwargs)
@@ -1473,7 +1473,8 @@ def build_provenance_function(
         prev_provenance = ds_rslt["ingest_metadata"]["dag_provenance_list"]
         if origin_keywords is not None:
             prev_provenance = [
-                data for data in prev_provenance
+                data
+                for data in prev_provenance
                 if any(kw in data["origin"] for kw in origin_keywords)
             ]
         kwargs["dag_run"].conf["dag_provenance_list"] = prev_provenance + new_dag_provenance
@@ -1660,14 +1661,20 @@ def make_send_status_msg_function(
                         if __is_true(val=v):
                             contacts.append(contrib)
 
-            if (segmentation_metadata := gather_segmentation_metadata(**kwargs).get("segmentation_metadata")) is not None:
+            if (
+                segmentation_metadata := gather_segmentation_metadata(**kwargs).get(
+                    "segmentation_metadata"
+                )
+            ) is not None:
                 md["segmentation_metadata"] = segmentation_metadata
 
             if not ds_rslt:
                 status = "QA"
             else:
                 status = ds_rslt.get("status", "QA")
-                if status in ["Processing", "New", "Invalid"]:
+                # With the exception of the JSON schema check, send_status_msg will not
+                # return an Error status
+                if status in ["Processing", "New", "Invalid", "Error"]:
                     status = (
                         "Submitted"
                         if kwargs["dag"].dag_id

--- a/tests/test_status_changer.py
+++ b/tests/test_status_changer.py
@@ -3,6 +3,7 @@ import json
 import unittest
 from datetime import date
 from functools import cached_property
+from unittest import mock
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import requests
@@ -470,6 +471,90 @@ class TestStatusChanger(MockParent):
                 message=message,
                 ds_state="Unknown",
             )
+
+    def status_changer_update(self, status: str, **kwargs):
+        with patch("status_change.status_manager.get_submission_context", **kwargs):
+            StatusChanger(
+                "dataset_valid_uuid",
+                "dataset_valid_token",
+                status=status,
+            ).update()
+
+    @patch("status_change.status_manager.StatusChanger.set_entity_api_data")
+    @patch("status_change.status_utils.get_ancestors")
+    def test_set_primary_status_derived(self, mock_get_ancestors, mock_set_data):
+        """
+        No change to derived status (new->new), primary in error: only primary status updated.
+        Derived status changed (new->qa), primary in error: update both.
+        """
+        mock_get_ancestors.return_value = (
+            {"entity_type": "Dataset", "uuid": "primary_dataset_uuid"},
+        )
+        for status in ["new", "qa"]:
+            self.status_changer_update(
+                status,
+                side_effect=[
+                    {
+                        "status": "New",
+                        "entity_type": "Dataset",
+                        "creation_action": "Central Process",
+                    },
+                    {
+                        "status": "Error",
+                        "entity_type": "Dataset",
+                    },
+                ],
+            )
+            self.mock_entity_update.assert_has_calls(
+                [
+                    mock.call(
+                        "primary_dataset_uuid",
+                        "dataset_valid_token",
+                        {"status": "QA"},
+                        {"reindex-priority": 3},
+                    ),
+                ]
+            )
+            self.mock_entity_update.reset_mock()
+            match status:
+                case "new":
+                    mock_set_data.assert_not_called()
+                case "qa":
+                    mock_set_data.assert_called_once()
+
+    @patch("status_change.status_manager.StatusChanger.set_entity_api_data")
+    @patch("status_change.status_manager.StatusChanger.update_primary_dataset")
+    def test_do_not_set_primary_status_derived_error(self, mock_update_primary, mock_set_data):
+        """
+        Derived status changed to non new/qa status (new->error), primary in error: do not update primary.
+        """
+        self.status_changer_update(
+            "error",
+            return_value={
+                "status": "New",
+                "entity_type": "Dataset",
+                "creation_action": "Central Process",
+            },
+        )
+        mock_set_data.assert_called_once()
+        mock_update_primary.assert_not_called()
+
+    @patch("status_change.status_manager.StatusChanger.set_entity_api_data")
+    @patch("status_change.status_manager.StatusChanger.update_primary_dataset")
+    def test_do_not_set_primary_status_not_derived(self, mock_update_primary, mock_set_data):
+        """
+        Dataset is not derived and status is unchanged, do not look for primary.
+        """
+        self.status_changer_update(
+            "new",
+            return_value={
+                "status": "New",
+                "entity_type": "Dataset",
+                "creation_action": "something else",
+            },
+        )
+        mock_set_data.assert_not_called()
+        mock_update_primary.assert_not_called()
 
     @patch("status_change.status_manager.StatusChanger")
     def test_get_any_dataset_uuid(self, sc_mock):

--- a/tests/test_status_changer.py
+++ b/tests/test_status_changer.py
@@ -510,7 +510,7 @@ class TestStatusChanger(MockParent):
                     mock.call(
                         "primary_dataset_uuid",
                         "dataset_valid_token",
-                        {"status": "QA"},
+                        {"status": "QA", "pipeline_message": ""},
                         {"reindex-priority": 3},
                     ),
                 ]


### PR DESCRIPTION
- Allows `make_send_status_msg_function` to reset Error status
- Allows `StatusChanger` to reset primary dataset status from Error->QA when a derived dataset reaches QA (or New, but that probably won't hit the `StatusChanger` I don't think)
     - Are we ever creating multiple derived datasets from the same primary simultaneously? This might hide failures if so.
- I believe we tabled the issue we were worried about where rerunning the `send_status_msg` DAG step might create duplicate provenance metadata. Instead of rerunning `send_status_msg`, reset the status manually if a DAG fails at or after the `send_status_msg` task (and restart subsequent tasks).